### PR TITLE
HARMONY-710: Job results and file downloading

### DIFF
--- a/examples/basic.ipynb
+++ b/examples/basic.ipynb
@@ -102,7 +102,7 @@
    "id": "tracked-distributor",
    "metadata": {},
    "source": [
-    "Now that we have a request, we can submit it to Harmony using the Harmony Client object we created earlier. We'll get back a JSON object that describes the Harmony job that we've submitted. As you can see, the Job contains the original request that was submitted to Harmony, its status, as well as a URL where we can get the Job's current status, and its results if it has completed."
+    "Now that we have a request, we can submit it to Harmony using the Harmony Client object we created earlier. We'll get back a job id belonging to our Harmony request."
    ]
   },
   {
@@ -116,11 +116,56 @@
    ]
   },
   {
+   "source": [
+    "If we want to, we can retrieve the job's status which includes information about the processing Harmony job."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "harmony_client.status(job1_id)"
+   ]
+  },
+  {
+   "source": [
+    "There are a number of options available for downloading results. We'll start with the 'download_all()' method which uses a multithreaded downloader and quickly returns with a \"future\" (specifically a python conccurrent.futures future).\n",
+    "\n",
+    "If you're unfamiliar with futures, at their most basic level they represent an eventual value. In our case, once a file is downloaded its future will contain the name of the local file. We can then hand the name off to other functions which open files based on their name to perform further operations. Work performed on behalf of each future takes place in a \"thread pool\" created for each Client instantiation.\n",
+    "\n",
+    "To extract the eventual value of a future, call its 'result()' method. By using futures we can process downloaded files as soon as they're ready while the rest of the files are still downloading in the background. Because of how we're working with the futures, the order of our results are maintained even though the files will likely be downloaded out of order."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f'\\n{job1_id}')\n",
+    "\n",
+    "print('\\nWaiting for the job to finish')\n",
+    "results = harmony_client.result_json(job1_id, show_progress=True)\n",
+    "\n",
+    "print('\\nDownloading results:')\n",
+    "futures = harmony_client.download_all(job1_id)\n",
+    "for f in futures:\n",
+    "    print(f.result())  # f.result() is a filename, in this case\n",
+    "print('\\nDone downloading.')"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "documented-membrane",
    "metadata": {},
    "source": [
-    "Now using our helper module, we'll wait for the Job to complete, and then we'll download the results and view them."
+    "Now using our helper module, we can view the files. Note that we're calling download_all() again here. Because the overwrite option is set to False (the default value), the method will see each of the files are already downloaded and will not do so again. It'll return quickly because it avoids the unnecessary work."
    ]
   },
   {
@@ -130,7 +175,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "helper.download_and_show_results(harmony_client, job1_id)"
+    "\n",
+    "futures = harmony_client.download_all(job1_id, overwrite=False)\n",
+    "filenames = [f.result() for f in futures]\n",
+    "for filename in filenames:\n",
+    "    helper.show_result(filename)"
    ]
   },
   {
@@ -159,13 +208,23 @@
    ]
   },
   {
+   "source": [
+    "With our second request, we've chosen to call 'wait_for_processing()'. This is optional as the other results oriented methods like downloading will implicitly wait for processing but this method can provide visual feedback to let us know if Harmony is still working on our submitted job."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "minus-hampton",
    "metadata": {},
    "outputs": [],
    "source": [
-    "helper.download_and_show_results(harmony_client, job2_id)"
+    "harmony_client.wait_for_processing(job2_id, show_progress=True)\n",
+    "\n",
+    "for filename in [f.result() for f in harmony_client.download_all(job2_id)]:\n",
+    "    helper.show_result(filename)"
    ]
   },
   {
@@ -201,7 +260,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "helper.download_and_show_results(harmony_client, job3_id)"
+    "for filename in [f.result() for f in harmony_client.download_all(job3_id)]:\n",
+    "    helper.show_result(filename)"
+   ]
+  },
+  {
+   "source": [
+    "If we're just interested in the json Harmony produces we can retrieve that also."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "harmony_client.result_json(job3_id)"
    ]
   },
   {
@@ -388,8 +464,7 @@
     "    crs='EPSG:3995',\n",
     "    format='image/tiff',\n",
     "    height=400,\n",
-    "    width=900,\n",
-    "    force_async=True\n",
+    "    width=900\n",
     ")\n",
     "request.is_valid()"
    ]
@@ -402,7 +477,8 @@
    "outputs": [],
    "source": [
     "job_id = harmony_client.submit(request)\n",
-    "helper.download_and_show_results(harmony_client, job_id)"
+    "for filename in [f.result() for f in harmony_client.download_all(job_id)]:\n",
+    "    helper.show_result(filename)"
    ]
   },
   {
@@ -430,7 +506,6 @@
     "    format='image/tiff',\n",
     "    height=400,\n",
     "    width=900,\n",
-    "    force_async=True,\n",
     "    variables=['red_var', 'green_var', 'blue_var']\n",
     ")\n",
     "request.is_valid()"
@@ -444,8 +519,17 @@
    "outputs": [],
    "source": [
     "job_id = harmony_client.submit(request)\n",
-    "helper.download_and_show_results(harmony_client, job_id)"
+    "\n",
+    "for filename in [f.result() for f in harmony_client.download_all(job_id)]:\n",
+    "    helper.show_result(filename)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -464,7 +548,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.8.5-final"
   }
  },
  "nbformat": 4,

--- a/examples/basic.ipynb
+++ b/examples/basic.ipynb
@@ -116,35 +116,39 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "confirmed-affair",
+   "metadata": {},
    "source": [
     "If we want to, we can retrieve the job's status which includes information about the processing Harmony job."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "sufficient-pleasure",
    "metadata": {},
    "outputs": [],
    "source": [
-    "harmony_client.status(job1_id)"
+    "helper.JSON(harmony_client.status(job1_id))"
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "threatened-complement",
+   "metadata": {},
    "source": [
     "There are a number of options available for downloading results. We'll start with the 'download_all()' method which uses a multithreaded downloader and quickly returns with a \"future\" (specifically a python conccurrent.futures future).\n",
     "\n",
     "If you're unfamiliar with futures, at their most basic level they represent an eventual value. In our case, once a file is downloaded its future will contain the name of the local file. We can then hand the name off to other functions which open files based on their name to perform further operations. Work performed on behalf of each future takes place in a \"thread pool\" created for each Client instantiation.\n",
     "\n",
     "To extract the eventual value of a future, call its 'result()' method. By using futures we can process downloaded files as soon as they're ready while the rest of the files are still downloading in the background. Because of how we're working with the futures, the order of our results are maintained even though the files will likely be downloaded out of order."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "global-ground",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,24 +269,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "northern-smith",
+   "metadata": {},
    "source": [
     "If we're just interested in the json Harmony produces we can retrieve that also."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "requested-reset",
    "metadata": {},
    "outputs": [],
    "source": [
-    "harmony_client.result_json(job3_id)"
+    "helper.JSON(harmony_client.result_json(job3_id))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "quality-earth",
+   "id": "speaking-archive",
    "metadata": {},
    "source": [
     "Now that we know how to make a request, let's investigate how the Harmony Py library can help us make sure we have a valid request. Recall that we used the Harmony `BBox` type to provide a spatial constraint in our request. If we investigate its help text, we see that we create a `BBox` by providing the western, southern, eastern, and northern latitude/longitude bounds for a bounding box."
@@ -441,21 +447,20 @@
   },
   {
    "cell_type": "markdown",
-   "id": "saving-professor",
+   "id": "personal-watts",
    "metadata": {},
    "source": [
-    "Or maybe you'd like to operate on some specific granules. In that case, passing the `granule_id` argument allows you to list the granule IDs (one or more) to operate upon. Let's try this in combination with another parameter: `crs`, the coordinate reference system we'd like to reproject our results into. In addition we show other options which specify what output format we'd like, the resulting image height and width, and `force_async` tells Harmony we'll come back later and check for our results -- don't hold up the notebook waiting for the result."
+    "Or maybe you'd like to operate on some specific granules. In that case, passing the `granule_id` argument allows you to list the granule IDs (one or more) to operate upon. Let's try this in combination with another parameter: `crs`, the coordinate reference system we'd like to reproject our results into. In addition we show other options which specify what output format we'd like, the resulting image height and width."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "progressive-crisis",
+   "id": "coated-denial",
    "metadata": {},
    "outputs": [],
    "source": [
-    "collection = Collection(id='C1234088182-EEDTEST'\n",
-    "                        )\n",
+    "collection = Collection(id='C1234088182-EEDTEST')\n",
     "\n",
     "request = Request(\n",
     "    collection=collection,\n",

--- a/examples/helper.py
+++ b/examples/helper.py
@@ -14,40 +14,6 @@ from rasterio.plot import show
 import requests
 
 
-def download_and_show_results_prev(harmony_client, job_id):
-    print('Waiting for the job to finish')
-
-    status = harmony_client.status(job_id)
-
-    while True:
-        status = harmony_client.status(job_id)
-        print(f"Job is {status['status']}: {status['progress']}%")
-        if status['status'] == 'successful':
-            break
-        else:
-            sleep(3)
-
-    print('Downloading results')
-    session = harmony_client._session()
-    harmony_job = session.get(harmony_client._status_url(job_id)).result().json()
-    print(harmony_job)
-    for result in [link for link in harmony_job['links'] if link['type'] == 'image/tiff']:
-        with open(result['title'], 'wb') as f:
-            print(f"  {result['title']}")
-            f.write(session.get(result['href']).result().content)
-            show(rasterio.open(result['title']))
-
-
-def download_and_show_results(harmony_client, job_id):
-    print('Waiting for the job to finish')
-    results = harmony_client.result_json(job_id, show_progress=True)
-
-    print('Downloading results')
-    files = harmony_client.download_all(job_id)
-    for f in files:
-        f.result()
-
-    for result in [link for link in results['links'] if link['type'] == 'image/tiff']:
-        with open(result['title'], 'wb') as f:
-            print(f"  {result['title']}")
-            show(rasterio.open(result['title']))
+def show_result(filename):
+    print (f'\n  {filename}')
+    show(rasterio.open(filename))

--- a/examples/helper.py
+++ b/examples/helper.py
@@ -14,7 +14,7 @@ from rasterio.plot import show
 import requests
 
 
-def download_and_show_results(harmony_client, job_id):
+def download_and_show_results_prev(harmony_client, job_id):
     print('Waiting for the job to finish')
 
     status = harmony_client.status(job_id)
@@ -35,4 +35,19 @@ def download_and_show_results(harmony_client, job_id):
         with open(result['title'], 'wb') as f:
             print(f"  {result['title']}")
             f.write(session.get(result['href']).result().content)
+            show(rasterio.open(result['title']))
+
+
+def download_and_show_results(harmony_client, job_id):
+    print('Waiting for the job to finish')
+    results = harmony_client.result_json(job_id, show_progress=True)
+
+    print('Downloading results')
+    files = harmony_client.download_all(job_id)
+    for f in files:
+        f.result()
+
+    for result in [link for link in results['links'] if link['type'] == 'image/tiff']:
+        with open(result['title'], 'wb') as f:
+            print(f"  {result['title']}")
             show(rasterio.open(result['title']))

--- a/examples/job_results.ipynb
+++ b/examples/job_results.ipynb
@@ -1,0 +1,157 @@
+{
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5-final"
+  },
+  "orig_nbformat": 2,
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3.8.5 64-bit ('harmony-py': venv)",
+   "metadata": {
+    "interpreter": {
+     "hash": "31862cc71836a94b0e0781803a3648767fc4cb197cc35bade0ddf231ddce7d7c"
+    }
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2,
+ "cells": [
+  {
+   "source": [
+    "## Harmony Py Library\n",
+    "### Job Results Example"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append('..')\n",
+    "from harmony import BBox, Client, Collection, Request\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "harmony_client = Client()  # assumes .netrc usage\n",
+    "\n",
+    "collection = Collection(id='C1234088182-EEDTEST')\n",
+    "request = Request(\n",
+    "    collection=collection,\n",
+    "    spatial=BBox(-165, 52, -140, 77)\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# submit an async request for processing and return the job_id\n",
+    "job_id = harmony_client.submit(request)\n",
+    "job_id\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We can check on the progress of a processing job with 'status()'.\n",
+    "# This method blocks while communicating with the server but returns quickly.\n",
+    "harmony_client.status(job_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 'wait_for_processing()'\n",
+    "# Optionally shows progress bar.\n",
+    "# Blocking.\n",
+    "harmony_client.wait_for_processing(job_id, show_progress=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 'result_json()' calls 'wait_for_processing()' and returns the complete job json once processing is complete.\n",
+    "# Optionally shows progress bar.\n",
+    "# Blocking.\n",
+    "data = harmony_client.result_json(job_id)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 'result_urls()' calls 'wait_for_processing()' and returns the job's data urls once processing is complete.\n",
+    "# Optionally shows progress bar.\n",
+    "# Blocking.\n",
+    "urls = harmony_client.result_urls(job_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 'download_all()' downloads all data urls and returns immediately with a list of concurrent.futures.\n",
+    "# Optionally shows progress bar for processing only.\n",
+    "# Non-blocking during download but blocking while waitinig for job processing to finish.\n",
+    "# Call 'result()' on future objects to realize them. A call to 'result()' blocks until that particular future finishes downloading. Other futures will download in the background, in parallel, up to the number of workers assigned to the thread pool (thread pool not publicly available).\n",
+    "# Downloading on any unfinished futures can be cancelled early.\n",
+    "# When downloading is complete the futures will return the file path string of the file that was just downloaded. This file path can then be fed into other libraries that may read the data files and perform other operations.\n",
+    "futures = harmony_client.download_all(job_id)\n",
+    "file_names = [f.result() for f in futures]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 'download()' will download only the url specified, in case a person would like more control over individual files.\n",
+    "# Returns a future containing the file path string of the file downloaded.\n",
+    "# Blocking upon calling result()\n",
+    "file_name = (harmony_client.download(urls[0], overwrite=True)).result()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ]
+}

--- a/harmony/config.py
+++ b/harmony/config.py
@@ -28,7 +28,8 @@ class Config:
     """
 
     config = {
-        'NUM_REQUESTS_WORKERS': '8',
+        'NUM_REQUESTS_WORKERS': '3',  # increase for servers
+        'DOWNLOAD_CHUNK_SIZE': str(4 * 1024 * 1024)  # recommend 16MB for servers
     }
 
     def __init__(self, environment: Environment = Environment.UAT) -> None:

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -385,8 +385,8 @@ class Client:
 
     def wait_for_processing(self, job_id: str, show_progress=False) -> None:
         check_interval = 3.0  # in seconds
-        sleep_interval = 0.33  # in seconds
-        intervals = int(check_interval / sleep_interval)
+        ui_update_interval = 0.33  # in seconds
+        intervals = int(check_interval / ui_update_interval)
         if show_progress:
             with progressbar.ProgressBar(max_value=100, widgets=progressbar_widgets) as bar:
                 progress = None
@@ -399,7 +399,7 @@ class Client:
                     if progress >= 100:
                         break
                     else:
-                        time.sleep(sleep_interval)
+                        time.sleep(ui_update_interval)
         else:
             while self.progress(job_id) < 100:
                 time.sleep(check_interval)

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -468,7 +468,7 @@ class Client:
 
         Performance should be close to native with an appropriate chunk size. This can be changed
         via environment variable DOWNLOAD_CHUNK_SIZE.
-        
+
         Filenames are automatically determined by using the latter portion of the provided URL.
 
         Args:
@@ -501,7 +501,7 @@ class Client:
 
         Performance should be close to native with an appropriate chunk size. This can be changed
         via environment variable DOWNLOAD_CHUNK_SIZE.
-        
+
         Filenames are automatically determined by using the latter portion of the provided URL.
 
         Will wait for an unfinished job to finish before downloading.

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -247,7 +247,7 @@ class Client:
         self.auth = auth
 
         num_workers = int(self.config.NUM_REQUESTS_WORKERS)
-        self.executor = executor = ThreadPoolExecutor(max_workers=num_workers)
+        self.executor = ThreadPoolExecutor(max_workers=num_workers)
 
         if should_validate_auth:
             validate_auth(self.config, self._session())
@@ -382,7 +382,6 @@ class Client:
         else:
             response.raise_for_status()
 
-
     def wait_for_processing(self, job_id: str, show_progress=False) -> None:
         check_interval = 3.0  # in seconds
         ui_update_interval = 0.33  # in seconds
@@ -404,18 +403,15 @@ class Client:
             while self.progress(job_id) < 100:
                 time.sleep(check_interval)
 
-
     def result_json(self, job_id: str, show_progress=False) -> str:
         self.wait_for_processing(job_id, show_progress)
         response = self._session().get(self._status_url(job_id))
         return response.json()
 
-
     def result_urls(self, job_id: str, show_progress=False) -> List:
         data = self.result_json(job_id, show_progress)
         urls = [x['href'] for x in data['links'] if x['rel'] == 'data']
         return urls
-
 
     def _download_file(self, url, directory=None, overwrite=False) -> str:
         chunksize = int(self.config.DOWNLOAD_CHUNK_SIZE)
@@ -423,7 +419,7 @@ class Client:
         filename = url.split('/')[-1]
 
         if directory:
-            filename = os.path.join(directory, local_filename)
+            filename = os.path.join(directory, filename)
 
         if not overwrite and os.path.isfile(filename):
             return filename
@@ -433,11 +429,9 @@ class Client:
                     shutil.copyfileobj(r.raw, f, length=chunksize)
             return filename
 
-
     def download(self, url, directory=None, overwrite=False) -> Future:
         future = self.executor.submit(self._download_file, url, directory, overwrite)
         return future
-
 
     def download_all(self, job_id: str, directory=None, overwrite=False) -> List[Future]:
         urls = self.result_urls(job_id, show_progress=False) or []

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -407,6 +407,11 @@ class Client:
                 for should_get in check_cycle:
                     if should_get:
                         progress = self.progress(job_id)
+                        # This gets around an issue with progressbar. If we update() with 0, the
+                        # output shows up as "N/A". If we update with, e.g. 0.1, it rounds down or
+                        # truncates to 0 but, importantly, actually displays that.
+                        if progress == 0:
+                            progress = 0.1
                     bar.update(progress)
                     sys.stdout.flush()  # ensures correct behavior in Jupyter notebooks
                     if progress >= 100:

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -15,6 +15,11 @@ from harmony.auth import create_session, validate_auth
 from harmony.config import Config, Environment
 
 
+# How often to poll Harmony for updated information during job processing.
+CHECK_INTERVAL = 3.0  # in seconds
+# How often to refresh the screen for progress updates and animating spinners.
+UI_UPDATE_INTERVAL = 0.33  # in seconds
+
 progressbar_widgets = [
     ' [ Processing: ', progressbar.Percentage(), ' ] ',
     progressbar.Bar(),
@@ -394,9 +399,7 @@ class Client:
         :raises Exception: This can happen if an invalid job_id is provided or Harmony services
         can't be reached.
         """
-        check_interval = 3.0  # in seconds
-        ui_update_interval = 0.33  # in seconds
-        intervals = int(check_interval / ui_update_interval)
+        intervals = int(CHECK_INTERVAL / UI_UPDATE_INTERVAL)
         if show_progress:
             with progressbar.ProgressBar(max_value=100, widgets=progressbar_widgets) as bar:
                 progress = None
@@ -409,10 +412,10 @@ class Client:
                     if progress >= 100:
                         break
                     else:
-                        time.sleep(ui_update_interval)
+                        time.sleep(UI_UPDATE_INTERVAL)
         else:
             while self.progress(job_id) < 100:
-                time.sleep(check_interval)
+                time.sleep(CHECK_INTERVAL)
 
     def result_json(self, job_id: str, show_progress: bool = False) -> str:
         """Retrieve a job's final json output.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -58,7 +58,6 @@ def test_authentication(status_code, should_error, config, mocker):
         auth_url,
         status=status_code
     )
-
     if should_error:
         with pytest.raises(BadAuthentication) as exc_info:
             actual_session = create_session(config)
@@ -71,8 +70,6 @@ def test_authentication(status_code, should_error, config, mocker):
         actual_session = create_session(config)
         validate_auth(config, actual_session)
         assert actual_session is not None
-
-
 
 
 def test_SessionWithHeaderRedirection_with_no_edl(mocker):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,6 +20,8 @@ def expected_status_url(job_id):
 
 
 def expected_full_submit_url(request):
+    async_params = ['forceAsync=True']
+
     spatial_params = []
     if request.spatial:
         w, s, e, n = request.spatial
@@ -31,7 +33,7 @@ def expected_full_submit_url(request):
         stop = request.temporal['stop']
         temporal_params = [f'subset=time("{start.isoformat()}":"{stop.isoformat()}")']
 
-    query_params = '&'.join(spatial_params + temporal_params)
+    query_params = '&'.join(async_params + spatial_params + temporal_params)
     if request.format is not None:
         query_params += f'&format{request.format}'
 
@@ -57,7 +59,8 @@ def expected_job(collection_id, job_id):
         'request': (
             'https://harmony.uat.earthdata.nasa.gov/{collection_id}/ogc-api-coverages/1.0.0'
             '/collections/all/coverage/rangeset'
-            '?subset=lat(52%3A77)'
+            '?forceAsync=True'
+            '&subset=lat(52%3A77)'
             '&subset=lon(-165%3A-140)'
             '&subset=time(%222010-01-01T00%3A00%3A00%22%3A%222020-12-30T00%3A00%3A00%22)'
         ),
@@ -187,7 +190,6 @@ def test_with_invalid_request():
 
 @pytest.mark.parametrize('param,expected', [
     ({'crs': 'epsg:3141'}, 'outputcrs=epsg:3141'),
-    ({'force_async': True}, 'forceAsync=true'),
     ({'format': 'r2d2/hologram'}, 'format=r2d2/hologram'),
     ({'granule_id': ['G1', 'G2', 'G3']}, 'granuleId=G1&granuleId=G2&granuleId=G3'),
     ({'height': 200}, 'height=200'),


### PR DESCRIPTION
WIP

This PR is for initial review on the approach taken for blocking and non-blocking job methods. Due to limitations with `requests-futures` I continue to use futures for eventual results but rolled in a different file downloading setup. The initial design tried to hide any use of futures from the end user but it ended up being bad, I think, because it removed the ability for the user to cancel downloads early. The current design is blocking on a per download basis but continues to download all other files in parallel up to the thread pool worker size. That means someone may work with / process a file while the others are streaming to disk. Other features present.

Please see examples/job_results.ipynb