### PR TITLE
HARMONY-711: Added job STAC URL retrieval in harmony.py.

### DIFF
--- a/examples/job_stac.ipynb
+++ b/examples/job_stac.ipynb
@@ -121,7 +121,11 @@
    "source": [
     "from pystac import Catalog\n",
     "\n",
-    "cat = Catalog.from_file(stac_catalog_url)"
+    "cat = Catalog.from_file(stac_catalog_url)\n",
+    "\n",
+    "print(cat.title)\n",
+    "for item in cat.get_all_items():\n",
+    "    print(item.datetime, [asset.href for asset in item.assets.values()])"
    ]
   },
   {

--- a/examples/job_stac.ipynb
+++ b/examples/job_stac.ipynb
@@ -1,0 +1,135 @@
+{
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5-final"
+  },
+  "orig_nbformat": 2,
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3.8.5 64-bit",
+   "metadata": {
+    "interpreter": {
+     "hash": "31862cc71836a94b0e0781803a3648767fc4cb197cc35bade0ddf231ddce7d7c"
+    }
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2,
+ "cells": [
+  {
+   "source": [
+    "## Harmony Py Library\n",
+    "### Job Results STAC data"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append('..')\n",
+    "from harmony import BBox, Client, Collection, Request\n"
+   ]
+  },
+  {
+   "source": [
+    "First, let's get a job processing in Harmony."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "harmony_client = Client()  # assumes .netrc usage\n",
+    "\n",
+    "collection = Collection(id='C1234088182-EEDTEST')\n",
+    "request = Request(\n",
+    "    collection=collection,\n",
+    "    spatial=BBox(-165, 52, -140, 77)\n",
+    ")\n",
+    "\n",
+    "job_id = harmony_client.submit(request)\n",
+    "job_id\n"
+   ]
+  },
+  {
+   "source": [
+    "Harmony-py can return the STAC Catalog URL for a completed job."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stac_catalog_url = harmony_client.stac_catalog_url(job_id, show_progress=True)\n"
+   ]
+  },
+  {
+   "source": [
+    "Following the directions for PySTAC (https://pystac.readthedocs.io/en/latest/quickstart.html), we can hook our harmony-py client into STAC_IO."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from urllib.parse import urlparse\n",
+    "import requests\n",
+    "from pystac import STAC_IO\n",
+    "\n",
+    "def requests_read_method(uri):\n",
+    "    parsed = urlparse(uri)\n",
+    "    if parsed.hostname.startswith('harmony.'):\n",
+    "        return harmony_client.read_text(uri)\n",
+    "    else:\n",
+    "        return STAC_IO.default_read_text_method(uri)\n",
+    "\n",
+    "STAC_IO.read_text_method = requests_read_method"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pystac import Catalog\n",
+    "\n",
+    "cat = Catalog.from_file(stac_catalog_url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ]
+}

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -269,9 +269,6 @@ class Client:
 
     def _status_url(self, job_id: str) -> str:
         return f'https://{self.config.harmony_hostname}/jobs/{job_id}'
-    
-    def _cloud_access_url(self): -> str:
-        return f'https://{self.config.harmony_hostname}/cloud-access'
 
     def _params(self, request: Request) -> dict:
         """Creates a dictionary of request query parameters from the given request."""

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -586,7 +586,6 @@ class Client:
             response.raise_for_status()
         return response.text
 
-
     def aws_credentials(self) -> dict:
         """Retrieve temporary AWS credentials for retrieving data in S3.
 

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -540,11 +540,9 @@ class Client:
             The filename and path.
         """
         urls = self.result_urls(job_id, show_progress=False) or []
-        futures = []
-        for url in urls:
-            future = self.executor.submit(self._download_file, url, directory, overwrite)
-            futures.append(future)
-        return futures
+        return [
+            self.executor.submit(self._download_file, url, directory, overwrite) for url in urls
+        ]
 
     def stac_catalog_url(self, job_id: str, show_progress: bool = False) -> str:
         """Extract the STAC catalog URL from job results.

--- a/requirements/examples.txt
+++ b/requirements/examples.txt
@@ -2,4 +2,5 @@ ipyplot ~= 1.1
 ipywidgets ~= 7.6
 jupyterlab ~= 3.0
 matplotlib ~= 3.3
+pystac ~= 0.5
 rasterio ~= 1.2

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -480,3 +480,35 @@ def test_download_all(mocker):
     actual_file_names = [f.result() for f in client.download_all('abcd-1234')]
     
     assert actual_file_names == expected_file_names
+
+
+def test_stac_catalog_url(mocker):
+    job_id = '1234'
+    collection = Collection(id='C1940468263-POCLOUD')
+    expected_json = expected_job(collection.id, job_id)
+    result_json_mock = mocker.Mock(return_value=expected_json)
+    mocker.patch('harmony.harmony.Client.result_json', result_json_mock)
+
+    expected_stac_catalog_url = f'https://harmony.uat.earthdata.nasa.gov/stac/{job_id}/'
+
+    client = Client(should_validate_auth=False)
+    actual_stac_catalog_url = client.stac_catalog_url(job_id)
+
+    assert actual_stac_catalog_url == expected_stac_catalog_url
+
+
+@responses.activate
+def test_read_text(mocker):
+    url = 'http://www.example.com/1234'
+    expected_text = '5678'
+    responses.add(
+        responses.GET,
+        url,
+        status=200,
+        body=expected_text
+    )
+
+    client = Client(should_validate_auth=False)
+    actual_text = client.read_text(url)
+
+    assert actual_text == expected_text


### PR DESCRIPTION
HARMONY-711: Added arbitrary URL retrieval from Client to support pystac
common usage.
HARMONY-711: Added example STAC notebook job_stac.ipynb.
HARMONY-711: examples.txt requirements file now uses pystac.

This card was just a small effort to retrieve the STAC URL and make it possible to feed STAC data into something like pystac.

The review notebook is in examples/job_stac.ipynb