### PR TITLE
HARMONY-712: Added the ability to retrieve a cloud access token for S3 URI's

### DIFF
--- a/examples/s3_access.ipynb
+++ b/examples/s3_access.ipynb
@@ -76,6 +76,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#\n",
+    "# NOTE: Execution of this cell will only succeed within the AWS us-west-2 region. \n",
+    "#\n",
+    "\n",
     "import boto3\n",
     "\n",
     "s3 = boto3.client('s3', **creds)\n",

--- a/examples/s3_access.ipynb
+++ b/examples/s3_access.ipynb
@@ -1,0 +1,101 @@
+{
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5-final"
+  },
+  "orig_nbformat": 2,
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3.8.5 64-bit",
+   "metadata": {
+    "interpreter": {
+     "hash": "31862cc71836a94b0e0781803a3648767fc4cb197cc35bade0ddf231ddce7d7c"
+    }
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2,
+ "cells": [
+  {
+   "source": [
+    "## Harmony Py Library\n",
+    "### Job Results Example"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append('..')\n",
+    "from harmony import BBox, Client, Collection, Request\n"
+   ]
+  },
+  {
+   "source": [
+    "Cloud access credentials can be retrieved from an instantiated Client."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "harmony_client = Client()  # assumes .netrc usage\n",
+    "\n",
+    "creds = harmony_client.aws_credentials()\n"
+   ]
+  },
+  {
+   "source": [
+    "Then, instantiate a boto3 client with those credentials."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "\n",
+    "s3 = boto3.client('s3', **creds)\n",
+    "uri = 's3://harmony-uat-staging/public/harmony/netcdf-to-zarr/817a3e99-d53c-4169-b9f1-82cc947793be/2020_01_01_7f00ff_global.zarr'\n",
+    "bucket_name = uri.split('/')[2]\n",
+    "object_name = '/'.join(uri.split('/')[3:])\n",
+    "file_name = uri.split('/')[-1]\n",
+    "\n",
+    "with open(file_name, 'wb') as f:\n",
+    "    # should return a 403 Forbidden if run outside of us-west-2\n",
+    "    s3.download_fileobj(bucket_name, object_name, f)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ]
+}

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -270,6 +270,9 @@ class Client:
     def _status_url(self, job_id: str) -> str:
         return f'https://{self.config.harmony_hostname}/jobs/{job_id}'
 
+    def _cloud_access_url(self) -> str:
+        return f'https://{self.config.harmony_hostname}/cloud-access'
+
     def _params(self, request: Request) -> dict:
         """Creates a dictionary of request query parameters from the given request."""
         params = {'forceAsync': True}
@@ -544,3 +547,26 @@ class Client:
             future = self.executor.submit(self._download_file, url, directory, overwrite)
             file_names.append(future)
         return file_names
+
+    def aws_credentials(self) -> dict:
+        """Retrieve temporary AWS credentials for retrieving data in S3.
+
+        Args:
+
+        Returns:
+            A python dict containing ``aws_access_key_id``, ``aws_secret_access_key``, and
+            ``aws_session_token``.
+
+        :raises Exception: Can raise when e.g. server is unreachable.
+        """
+        creds_keys = ['AccessKeyId', 'SecretAccessKey', 'SessionToken']
+        response = self._session().get(self._cloud_access_url())
+        if not response.ok:
+            response.raise_for_status()
+        cloud_access = response.json()
+        creds = {
+            'aws_access_key_id': cloud_access['AccessKeyId'],
+            'aws_secret_access_key': cloud_access['SecretAccessKey'],
+            'aws_session_token': cloud_access['SessionToken'],
+        }
+        return creds

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -559,7 +559,6 @@ class Client:
 
         :raises Exception: Can raise when e.g. server is unreachable.
         """
-        creds_keys = ['AccessKeyId', 'SecretAccessKey', 'SessionToken']
         response = self._session().get(self._cloud_access_url())
         if not response.ok:
             response.raise_for_status()

--- a/requirements/examples.txt
+++ b/requirements/examples.txt
@@ -1,3 +1,4 @@
+boto3 ~= 1.17
 ipyplot ~= 1.1
 ipywidgets ~= 7.6
 jupyterlab ~= 3.0


### PR DESCRIPTION
This was a very small card to retrieve a cloud access token. NOTE: no additional unit tests included; I'd be happy to contribute one or more as part of 715.

The review notebook is in examples/s3_access.ipynb