### PR TITLE
HARMONY-905: Update all notebooks to install their own dependencies

### DIFF
--- a/examples/basic.ipynb
+++ b/examples/basic.ipynb
@@ -17,6 +17,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "59eaa108-53e0-40dd-83f7-1c81d21a1e42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install notebook requirements\n",
+    "import sys; sys.path.append('..')\n",
+    "!{sys.executable} -m pip install -q -r ../requirements/examples.txt\n",
+    "\n",
+    "# Install harmony-py requirements.  Not necessary if you ran `pip install harmony-py` in your kernel  \n",
+    "!{sys.executable} -m pip install -q -r ../requirements/core.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "knowing-atlas",
    "metadata": {},
    "outputs": [],
@@ -212,11 +227,12 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "9e1a5fd5",
+   "metadata": {},
    "source": [
     "With our second request, we've chosen to call 'wait_for_processing()'. This is optional as the other results oriented methods like downloading will implicitly wait for processing but this method can provide visual feedback to let us know if Harmony is still working on our submitted job."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -532,6 +548,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8d0ff231",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -539,7 +556,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -553,7 +570,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5-final"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/examples/intro_tutorial.ipynb
+++ b/examples/intro_tutorial.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "1fdecb55",
    "metadata": {},
    "source": [
     "## HarmonyPy Introduction\n",
@@ -11,7 +12,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "e78bfac8",
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "### Import packages\n",
     "\n",
@@ -32,11 +36,25 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ed97d7e6-795a-41d7-9025-3f5a9b360e34",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# !{sys.executable} -m pip install -U harmony-py #install harmony-py into Python kernel\n",
+    "# Install notebook requirements\n",
     "import sys; sys.path.append('..')\n",
+    "!{sys.executable} -m pip install -q -r ../requirements/examples.txt\n",
+    "\n",
+    "# Install harmony-py requirements.  Not necessary if you ran `pip install harmony-py` in your kernel  \n",
+    "!{sys.executable} -m pip install -q -r ../requirements/core.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16815631",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import datetime as dt\n",
     "from IPython.display import display, JSON\n",
     "import rasterio\n",
@@ -48,6 +66,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5756b9cb",
    "metadata": {},
    "source": [
     "### Quick start\n",
@@ -71,6 +90,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5761b37e",
    "metadata": {},
    "source": [
     "The guidance below offers more detailed examples highlighting many of the helpful features provided by the Harmony Py library, including direct s3 access from Earthdata Cloud-hosted data if running in the AWS us-west-2 region."
@@ -78,6 +98,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "55fe72b5",
    "metadata": {},
    "source": [
     "### Create Harmony Client object\n",
@@ -121,6 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "710e9f40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,6 +151,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0e98db2c",
    "metadata": {},
    "source": [
     "### Create Harmony Request\n",
@@ -157,6 +180,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4945d617",
    "metadata": {},
    "source": [
     "The example utilized in this tutorial demonstrates a shapefile subset of the Big Island of Hawaii on February 24, 2020. A bounding box subset over the Mauna Kea and Mauna Loa volcanoes is also commented out below to show a similar subsetting option. The SENTINEL-1_INTERFEROGRAMS dataset, distributed by the ASF DAAC, is a prototype Level 2 NISAR-Format product. See https://asf.alaska.edu/data-sets/derived-data-sets/sentinel-1-interferograms/ for more information. \n",
@@ -170,6 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d5e3dd34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,6 +216,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7cfa596e",
    "metadata": {},
    "source": [
     "### Check Request validity\n",
@@ -201,6 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d67e01f1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -211,6 +238,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1897a407",
    "metadata": {},
    "source": [
     "### Submit Request\n",
@@ -221,6 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "07ecfd25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,6 +259,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "175d09bb",
    "metadata": {},
    "source": [
     "### Check Request status\n",
@@ -240,6 +270,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5b320ac5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,6 +279,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7bee7f9f",
    "metadata": {},
    "source": [
     "Depending on the size of the request, you may want to wait until the request has completed processing before the remainder of your code is executed. The `wait_for_processing()` method will block subsequent lines of code while optinally showing a progress bar."
@@ -256,6 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "be0dabc1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,6 +297,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "41452b7c",
    "metadata": {},
    "source": [
     "### View Harmony job response and output URLs\n",
@@ -276,6 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "feff999b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -285,6 +320,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "02567b42",
    "metadata": {},
    "source": [
     "### Download and visualize Harmony output files\n",
@@ -299,6 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b26d572c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -308,6 +345,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "55aac772",
    "metadata": {},
    "source": [
     "#### Download files"
@@ -315,6 +353,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1a46cae7",
    "metadata": {},
    "source": [
     "The next code block utilizes `download_all()` to download all data output file URLs. This is a non-blocking step during the download itself, but this line will block subsequent code while waiting for the job to finish processing. You can optionally specify a directory and specify whether to overwrite existing files as shown below.\n",
@@ -325,6 +364,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4f97b857",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -335,6 +375,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d32f878f",
    "metadata": {},
    "source": [
     "With `download()`, this will download only the URL specified, in case you would like more control over individual files."
@@ -343,6 +384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6ac86478",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -352,6 +394,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0fc6cfc0",
    "metadata": {},
    "source": [
     "### Visualize Downloaded Outputs\n",
@@ -362,6 +405,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0c8eaad6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -371,6 +415,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "edfea75c",
    "metadata": {},
    "source": [
     "### Explore output STAC catalog and retrieve results from s3\n",
@@ -381,6 +426,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ef42bb5b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -390,6 +436,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3027a2d9",
    "metadata": {},
    "source": [
     "#### Using PySTAC:"
@@ -397,6 +444,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2d3d9fff",
    "metadata": {},
    "source": [
     "Following the directions for PySTAC (https://pystac.readthedocs.io/en/latest/quickstart.html), we can hook our harmony-py client into STAC_IO."
@@ -405,6 +453,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "844b5ab8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -424,6 +473,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b52d2679",
    "metadata": {},
    "source": [
     "View the timestamp and s3 locations of each STAC item:"
@@ -432,6 +482,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b1342ccd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -448,6 +499,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f4d9c649",
    "metadata": {},
    "source": [
     "#### Using intake-stac:\n",
@@ -458,6 +510,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ef1eeb66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -468,6 +521,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "583eca0f",
    "metadata": {},
    "source": [
     "And the metadata contents of each item:"
@@ -476,6 +530,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "914e0315",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -487,6 +542,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7edd3d65",
    "metadata": {},
    "source": [
     "### Cloud in-place access \n",
@@ -498,6 +554,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "89054073",
    "metadata": {},
    "source": [
     "#### AWS credential retrieval\n",
@@ -508,6 +565,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b278020a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -517,6 +575,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "aa00b059",
    "metadata": {},
    "source": [
     "#### Using boto3"
@@ -525,6 +584,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "45f798d9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -546,6 +606,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9b86e8e1",
    "metadata": {},
    "source": [
     "#### Using intake-stac\n",
@@ -556,6 +617,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "92e969d1",
    "metadata": {
     "tags": []
    },
@@ -574,7 +636,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -588,7 +650,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/examples/job_results.ipynb
+++ b/examples/job_results.ipynb
@@ -92,7 +92,7 @@
    "source": [
     "# 'result_urls()' calls 'wait_for_processing()' and returns the job's data urls once processing is complete.\n",
     "# Optionally shows progress bar.\n",
-    "# Blocking.\n",
+    "# Blocking. Returns a generator to support returning many pages of results.\n",
     "urls = harmony_client.result_urls(job_id)"
    ]
   },
@@ -121,7 +121,7 @@
     "# 'download()' will download only the url specified, in case a person would like more control over individual files.\n",
     "# Returns a future containing the file path string of the file downloaded.\n",
     "# Blocking upon calling result()\n",
-    "file_name = harmony_client.download(urls[0], overwrite=True).result()\n"
+    "file_name = harmony_client.download(next(urls), overwrite=True).result()\n"
    ]
   },
   {

--- a/examples/job_results.ipynb
+++ b/examples/job_results.ipynb
@@ -1,34 +1,12 @@
 {
- "metadata": {
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.5-final"
-  },
-  "orig_nbformat": 2,
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3",
-   "language": "python"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2,
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Harmony Py Library\n",
     "### Job Results Example"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -38,6 +16,10 @@
    "source": [
     "import sys\n",
     "sys.path.append('..')\n",
+    "\n",
+    "# Install harmony-py requirements.  Not necessary if you ran `pip install harmony-py` in your kernel  \n",
+    "!{sys.executable} -m pip install -q -r ../requirements/core.txt\n",
+    "\n",
     "from harmony import BBox, Client, Collection, Request, Environment\n"
    ]
   },
@@ -149,5 +131,26 @@
    "outputs": [],
    "source": []
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/examples/job_stac.ipynb
+++ b/examples/job_stac.ipynb
@@ -1,38 +1,12 @@
 {
- "metadata": {
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.5-final"
-  },
-  "orig_nbformat": 2,
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3.8.5 64-bit",
-   "metadata": {
-    "interpreter": {
-     "hash": "31862cc71836a94b0e0781803a3648767fc4cb197cc35bade0ddf231ddce7d7c"
-    }
-   }
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2,
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Harmony Py Library\n",
     "### Job Results STAC data"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -42,15 +16,20 @@
    "source": [
     "import sys\n",
     "sys.path.append('..')\n",
+    "!{sys.executable} -m pip install -q -r ../requirements/examples.txt\n",
+    "\n",
+    "# Install harmony-py requirements.  Not necessary if you ran `pip install harmony-py` in your kernel  \n",
+    "!{sys.executable} -m pip install -q -r ../requirements/core.txt\n",
+    "\n",
     "from harmony import BBox, Client, Collection, Request, Environment\n"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "First, let's get a job processing in Harmony."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -71,11 +50,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Harmony-py can return the STAC Catalog URL for a completed job."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -87,11 +66,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Following the directions for PySTAC (https://pystac.readthedocs.io/en/latest/quickstart.html), we can hook our harmony-py client into STAC_IO."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -135,5 +114,26 @@
    "outputs": [],
    "source": []
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/examples/job_status.ipynb
+++ b/examples/job_status.ipynb
@@ -1,38 +1,12 @@
 {
- "metadata": {
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.5-final"
-  },
-  "orig_nbformat": 2,
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3.8.5 64-bit",
-   "metadata": {
-    "interpreter": {
-     "hash": "31862cc71836a94b0e0781803a3648767fc4cb197cc35bade0ddf231ddce7d7c"
-    }
-   }
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2,
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Harmony Py Library\n",
     "### Job Status Example"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -42,6 +16,10 @@
    "source": [
     "import sys\n",
     "sys.path.append('..')\n",
+    "\n",
+    "# Install harmony-py requirements.  Not necessary if you ran `pip install harmony-py` in your kernel  \n",
+    "!{sys.executable} -m pip install -q -r ../requirements/core.txt\n",
+    "\n",
     "from harmony import BBox, Client, Collection, Request, Environment\n"
    ]
   },
@@ -85,5 +63,26 @@
    "outputs": [],
    "source": []
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/examples/s3_access.ipynb
+++ b/examples/s3_access.ipynb
@@ -17,6 +17,11 @@
     "import datetime as dt\n",
     "import sys\n",
     "sys.path.append('..')\n",
+    "!{sys.executable} -m pip install -q -r ../requirements/examples.txt\n",
+    "\n",
+    "# Install harmony-py requirements.  Not necessary if you ran `pip install harmony-py` in your kernel  \n",
+    "!{sys.executable} -m pip install -q -r ../requirements/core.txt\n",
+    "\n",
     "from harmony import BBox, Client, Collection, LinkType, Request, s3_components, Environment"
    ]
   },
@@ -108,7 +113,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -122,7 +127,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/examples/shapefile_subset.ipynb
+++ b/examples/shapefile_subset.ipynb
@@ -9,11 +9,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Set up a harmony client pointing to UAT"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -23,17 +23,22 @@
    "source": [
     "import sys\n",
     "sys.path.append('..')\n",
+    "!{sys.executable} -m pip install -q -r ../requirements/examples.txt\n",
+    "\n",
+    "# Install harmony-py requirements.  Not necessary if you ran `pip install harmony-py` in your kernel  \n",
+    "!{sys.executable} -m pip install -q -r ../requirements/core.txt\n",
+    "\n",
     "from harmony import BBox, Client, Collection, Request, Environment\n",
     "\n",
     "harmony_client = Client(env=Environment.UAT)"
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Perform a shapefile subsetting request on a supported collection by passing the path to a GeoJSON file (*.json or *.geojson), an ESRI Shapefile (*.zip or *.shz), or a kml file (*.kml) as the \"shape\" parameter"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -51,11 +56,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Wait for processing and then view the output"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -83,7 +88,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -20,6 +20,11 @@
    "outputs": [],
    "source": [
     "import sys; sys.path.append('..')\n",
+    "!{sys.executable} -m pip install -q -r ../requirements/examples.txt\n",
+    "\n",
+    "# Install harmony-py requirements.  Not necessary if you ran `pip install harmony-py` in your kernel  \n",
+    "!{sys.executable} -m pip install -q -r ../requirements/core.txt\n",
+    "\n",
     "import datetime as dt\n",
     "from IPython.display import display, JSON\n",
     "import rasterio\n",
@@ -165,7 +170,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -179,7 +184,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
To test, start a clean kernel with only Jupyter installed and verify the notebooks work.

Note there is one issue that's external to us: intake-stac depends on sat-stac, which depends on a version of dateutils that conflicts with the version Jupyter Lab itself needs.  There's a PR out to sat-stac to fix it, which I pinged @matthewhanson about https://github.com/sat-utils/sat-stac/pull/69 so I'm treating it as external