### PR TITLE
Add request as curl function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,5 @@ examples/*.nc.tif
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/
+
+.idea

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -3,3 +3,4 @@ python-dotenv ~= 0.1
 progressbar2 ~= 3.5
 requests ~= 2.2
 sphinxcontrib-napoleon >= 0.7
+curlify ~= 2.2

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -691,3 +691,31 @@ def test_read_text(mocker):
     actual_text = client.read_text(url)
 
     assert actual_text == expected_text
+
+
+def test_request_as_curl_get():
+    collection = Collection(id='C1940468263-POCLOUD')
+    request = Request(
+        collection=collection,
+        spatial=BBox(-107, 40, -105, 42)
+    )
+
+    curl_command = Client(should_validate_auth=False).request_as_curl(request)
+    assert f'https://harmony.earthdata.nasa.gov/{collection.id}' \
+           f'/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset' in curl_command
+    assert '-X GET' in curl_command
+
+
+def test_request_as_curl_post():
+    collection = Collection(id='C1940468263-POCLOUD')
+    request = Request(
+        collection=collection,
+        shape='./examples/asf_example.json',
+        spatial=BBox(-107, 40, -105, 42)
+    )
+
+    curl_command = Client(should_validate_auth=False).request_as_curl(request)
+    assert f'https://harmony.earthdata.nasa.gov/{collection.id}' \
+           f'/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset' in curl_command
+    assert '-X POST' in curl_command
+


### PR DESCRIPTION
In some situations, I'd like to be able to see the request that is going to be submitted to Harmony before actually submitting it (in Jupyter notebooks for example).

Thought the easiest way to do that would be to curlify the request since the request can also include POST data content.