### PR TITLE
HARMONY-994: Allow use of concatenate param

### DIFF
--- a/examples/basic.ipynb
+++ b/examples/basic.ipynb
@@ -109,7 +109,6 @@
     "request = Request(\n",
     "    collection=collection,\n",
     "    spatial=BBox(-165, 52, -140, 77),\n",
-    "    # concatenate=False (default is no concatenation)\n",
     ")"
    ]
   },

--- a/examples/basic.ipynb
+++ b/examples/basic.ipynb
@@ -108,7 +108,7 @@
     "\n",
     "request = Request(\n",
     "    collection=collection,\n",
-    "    spatial=BBox(-165, 52, -140, 77),\n",
+    "    spatial=BBox(-165, 52, -140, 77)\n",
     ")"
    ]
   },

--- a/examples/basic.ipynb
+++ b/examples/basic.ipynb
@@ -108,7 +108,8 @@
     "\n",
     "request = Request(\n",
     "    collection=collection,\n",
-    "    spatial=BBox(-165, 52, -140, 77)\n",
+    "    spatial=BBox(-165, 52, -140, 77),\n",
+    "    # concatenate=False (default is no concatenation)\n",
     ")"
    ]
   },

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "## Harmony Py Tutorial\n",
     "\n",
-    "This notebook shows three basic examples of Harmony jobs, each using a Harmony test Collection. The first example requests a spatial subset of Alaska, the second a temporal subset (a single-month timespan), and the third shows a combination of both spatial and temporal subsetting.\n",
+    "This notebook shows a basic examples of a Harmony job, using a Harmony test Collection, to perform a combination of both spatial and temporal subsetting.\n",
     "\n",
     "First, we import a few things that will help us create a request and display images. We then import the Harmony Py classes we need to make a request."
    ]
@@ -89,6 +89,7 @@
     "    format='image/tiff',\n",
     "    height=512,\n",
     "    width=512\n",
+    "    # concatenate=False (default is no concatenation)\n",
     ")\n",
     "\n",
     "request.is_valid()"

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "## Harmony Py Tutorial\n",
     "\n",
-    "This notebook shows a basic example of a Harmony job, using a Harmony test Collection, to perform a combination of both spatial and temporal subsetting.\n",
+    "This notebook shows a basic example of a Harmony job using a Harmony test Collection to perform a combination of both spatial and temporal subsetting.\n",
     "\n",
     "First, we import a few things that will help us create a request and display images. We then import the Harmony Py classes we need to make a request."
    ]

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -89,7 +89,6 @@
     "    format='image/tiff',\n",
     "    height=512,\n",
     "    width=512\n",
-    "    # concatenate=False (default is no concatenation)\n",
     ")\n",
     "\n",
     "request.is_valid()"

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "## Harmony Py Tutorial\n",
     "\n",
-    "This notebook shows a basic examples of a Harmony job, using a Harmony test Collection, to perform a combination of both spatial and temporal subsetting.\n",
+    "This notebook shows a basic example of a Harmony job, using a Harmony test Collection, to perform a combination of both spatial and temporal subsetting.\n",
     "\n",
     "First, we import a few things that will help us create a request and display images. We then import the Harmony Py classes we need to make a request."
    ]

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -153,6 +153,8 @@ class Request:
 
         max_results: limits the number of input granules processed in the request
 
+        concatenate: Whether to invoke a service that supports concatenation
+
     Returns:
         A Harmony Request instance
     """
@@ -172,7 +174,8 @@ class Request:
                  scale_size: List[float] = None,
                  shape: Optional[Tuple[IO, str]] = None,
                  variables: List[str] = ['all'],
-                 width: int = None):
+                 width: int = None,
+                 concatenate: bool = None):
         """Creates a new Request instance from all specified criteria.'
         """
         self.collection = collection
@@ -189,6 +192,7 @@ class Request:
         self.shape = shape
         self.variables = variables
         self.width = width
+        self.concatenate = concatenate
 
         self.variable_name_to_query_param = {
             'crs': 'outputcrs',
@@ -201,6 +205,7 @@ class Request:
             'height': 'height',
             'format': 'format',
             'max_results': 'maxResults',
+            'concatenate': 'concatenate'
         }
 
         self.spatial_validations = [

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -338,6 +338,7 @@ def test_post_request_has_user_agent_headers():
     ({'scale_extent': [1.0, 2.0, 1.0, 4.0]}, 'scaleExtent=1.0,2.0,1.0,4.0'),
     ({'scale_size': [1.0, 2.0]}, 'scaleSize=1.0,2.0'),
     ({'width': 100}, 'width=100'),
+    ({'concatenate': True}, 'concatenate=true'),
 ])
 @responses.activate
 def test_request_has_query_param(param, expected):


### PR DESCRIPTION
~Will run `make docs` once I confirm that these changes are ok. Was a little difficult to find a logical place in the user-facing documentation to describe concatenate. Considered adding a new notebook example but I'm guessing someone else will likely do that during demos.~ (resolved)

I can test via a live example once the concatenation service is in available.