### PR TITLE
GDDS-166 - Allow bounding box southern and northern extents to be equal.

### DIFF
--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -209,7 +209,8 @@ class Request:
         }
 
         self.spatial_validations = [
-            (lambda bb: bb.s <= bb.n, 'Southern latitude must be less than or equal to Northern latitude'),
+            (lambda bb: bb.s <= bb.n, ('Southern latitude must be less than '
+                                       'or equal to Northern latitude')),
             (lambda bb: bb.s >= -90.0, 'Southern latitude must be greater than -90.0'),
             (lambda bb: bb.n >= -90.0, 'Northern latitude must be greater than -90.0'),
             (lambda bb: bb.s <= 90.0, 'Southern latitude must be less than 90.0'),

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -209,7 +209,7 @@ class Request:
         }
 
         self.spatial_validations = [
-            (lambda bb: bb.s < bb.n, 'Southern latitude must be less than Northern latitude'),
+            (lambda bb: bb.s <= bb.n, 'Southern latitude must be less than or equal to Northern latitude'),
             (lambda bb: bb.s >= -90.0, 'Southern latitude must be greater than -90.0'),
             (lambda bb: bb.n >= -90.0, 'Northern latitude must be greater than -90.0'),
             (lambda bb: bb.s <= 90.0, 'Southern latitude must be less than 90.0'),

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -39,7 +39,7 @@ def test_request_spatial_bounding_box(west, south, east, north):
         assert e == east
         assert n == north
 
-        assert south < north
+        assert south <= north
 
         assert south >= -90.0
         assert north >= -90.0
@@ -75,7 +75,7 @@ def test_request_temporal_range(key_a, key_b, datetime_a, datetime_b):
 
 
 @pytest.mark.parametrize('key, value, message', [
-    ('spatial', BBox(10, -10, 20, -20), 'Southern latitude must be less than Northern latitude'),
+    ('spatial', BBox(10, -10, 20, -20), 'Southern latitude must be less than or equal to Northern latitude'),
     ('spatial', BBox(10, -100, 20, 20), 'Southern latitude must be greater than -90.0'),
     ('spatial', BBox(10, -110, 20, -100), 'Northern latitude must be greater than -90.0'),
     ('spatial', BBox(10, 100, 20, 110), 'Southern latitude must be less than 90.0'),


### PR DESCRIPTION
This PR makes a minor change to the bounding box validation within `harmony-py` to ensure that if a user specifies northern and southern extents that are equal, that request is considered valid. This allows a user to specify a single point or horizontal line for subsetting via a bounding box. Harmony itself already supports this behaviour, for example:

```
https://harmony.uat.earthdata.nasa.gov/C1225808238-GES_DISC/ogc-api-coverages/1.0.0/collections/%2FGrid%2FprecipitationCal/coverage/rangeset?forceAsync=true&granuleId=G1240992035-GES_DISC&subset=lat(20%3A20)&subset=lon(160%3A160)
```

This has become recently notable because GES-DISC are hoping to support single-point spatial subsetting via HOSS in production (see [GDDS-166](https://bugs.earthdata.nasa.gov/browse/GDDS-166)).