### PR TITLE
Add human readable dates to status output

### DIFF
--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -588,12 +588,16 @@ class Client:
                 'numInputGranules'
             ]
             status_subset = {k: v for k, v in response.json().items() if k in fields}
+            created_at_dt = dateutil.parser.parse(status_subset['createdAt'])
+            updated_at_dt = dateutil.parser.parse(status_subset['updatedAt'])
             return {
                 'status': status_subset['status'],
                 'message': status_subset['message'],
                 'progress': status_subset['progress'],
-                'created_at': dateutil.parser.parse(status_subset['createdAt']),
-                'updated_at': dateutil.parser.parse(status_subset['updatedAt']),
+                'created_at': created_at_dt,
+                'updated_at': updated_at_dt,
+                'created_at_local': created_at_dt.replace(microsecond=0).astimezone().isoformat(),
+                'updated_at_local': updated_at_dt.replace(microsecond=0).astimezone().isoformat(),
                 'request': status_subset['request'],
                 'num_input_granules': int(status_subset['numInputGranules']),
             }


### PR DESCRIPTION
Just a little quality of life update.

Added local datetime representation to status output to make it easier to read the times when viewed in a Jupyter notebook. Also updated tests to load examples from directory relative to the test_client.py file instead of relative to the current working directory where tests are being run.

Example of what the output of `status` returns after this change:

```
{
'created_at': datetime.datetime(2021, 2, 19, 18, 47, 31, 291000, tzinfo=tzutc()),
 'created_at_local': '2021-02-19T10:47:31-08:00',
 'message': 'The job is being processed',
 'num_input_granules': 32,
 'progress': 0,
 'request': 'https://harmony.earthdata.nasa.gov/{collection_id}/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=True&subset=lat(52%3A77)&subset=lon(-165%3A-140)&subset=time(%222010-01-01T00%3A00%3A00%22%3A%222020-12-30T00%3A00%3A00%22)',
 'status': 'running',
 'updated_at': datetime.datetime(2021, 2, 19, 18, 47, 31, 291000, tzinfo=tzutc()),
 'updated_at_local': '2021-02-19T10:47:31-08:00'
}
```

