### PR TITLE
HARMONY-1134: Added `skip_preview` flag to `Request`

### DIFF
--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -155,6 +155,8 @@ class Request:
 
         concatenate: Whether to invoke a service that supports concatenation
 
+        skip_preview: Whether Harmony should skip auto-pausing and generating a preview for large jobs
+
     Returns:
         A Harmony Request instance
     """
@@ -175,7 +177,8 @@ class Request:
                  shape: Optional[Tuple[IO, str]] = None,
                  variables: List[str] = ['all'],
                  width: int = None,
-                 concatenate: bool = None):
+                 concatenate: bool = None,
+                 skip_preview: bool = True):
         """Creates a new Request instance from all specified criteria.'
         """
         self.collection = collection
@@ -193,6 +196,7 @@ class Request:
         self.variables = variables
         self.width = width
         self.concatenate = concatenate
+        self.skip_preview = skip_preview
 
         self.variable_name_to_query_param = {
             'crs': 'outputcrs',
@@ -205,7 +209,8 @@ class Request:
             'height': 'height',
             'format': 'format',
             'max_results': 'maxResults',
-            'concatenate': 'concatenate'
+            'concatenate': 'concatenate',
+            'skip_preview': 'skipPreview',
         }
 
         self.spatial_validations = [

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -155,7 +155,8 @@ class Request:
 
         concatenate: Whether to invoke a service that supports concatenation
 
-        skip_preview: Whether Harmony should skip auto-pausing and generating a preview for large jobs
+        skip_preview: Whether Harmony should skip auto-pausing and generating a preview for
+          large jobs
 
     Returns:
         A Harmony Request instance

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -43,6 +43,8 @@ def expected_full_submit_url(request):
     query_params = '&'.join(async_params + spatial_params + temporal_params)
     if request.format is not None:
         query_params += f'&format{request.format}'
+    if request.skip_preview is not None:
+        query_params += f'&skipPreview={str(request.skip_preview).lower()}'
 
     return f'{expected_submit_url(request.collection.id)}?{query_params}'
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -18,6 +18,14 @@ def test_request_with_only_a_collection():
     request = Request(collection=Collection('foobar'))
     assert request.is_valid()
 
+def test_request_with_skip_preview():
+    request = Request(collection=Collection('foobar'), skip_preview=False)
+    assert request.is_valid()
+    assert request.skip_preview is not None
+
+def test_request_defaults_to_skip_preview_true():
+    request = Request(collection=Collection('foobar'))
+    assert request.skip_preview
 
 @settings(max_examples=200)
 @given(west=st.floats(allow_infinity=True),

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -18,10 +18,15 @@ def test_request_with_only_a_collection():
     request = Request(collection=Collection('foobar'))
     assert request.is_valid()
 
-def test_request_with_skip_preview():
+def test_request_with_skip_preview_false():
     request = Request(collection=Collection('foobar'), skip_preview=False)
     assert request.is_valid()
-    assert request.skip_preview is not None
+    assert request.skip_preview is not None and request.skip_preview == False
+
+def test_request_with_skip_preview_true():
+    request = Request(collection=Collection('foobar'), skip_preview=True)
+    assert request.is_valid()
+    assert request.skip_preview is not None and request.skip_preview == True
 
 def test_request_defaults_to_skip_preview_true():
     request = Request(collection=Collection('foobar'))


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1134

## Description
This PR adds the `skip_preview` parameter to `Request`. For now it defaults to `True`, because the library does not yet support pause/resume, so we don't want large jobs to be paused with no way to resume them. I have not modified any of
the notebooks yet for the same reason.

## Local Test Steps
In the `job_status` notebook change the request to 
```
harmony_client = Client(env=Environment.UAT)  # assumes .netrc usage

collection = Collection(id='C1234088182-EEDTEST')
request = Request(
    collection=collection,
    skip_preview=False
    
)
```
then execute the first four cells - the status returned should show the job is previewing (or paused if you are slow).

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)