### PR TITLE
Harmony 1135 harmony-py pause resume

### DIFF
--- a/examples/job_pause_resume.ipynb
+++ b/examples/job_pause_resume.ipynb
@@ -1,0 +1,190 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Harmony Py Library\n",
+    "### Job Pause/Resume Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.append('..')\n",
+    "\n",
+    "# Install harmony-py requirements.  Not necessary if you ran `pip install harmony-py` in your kernel  \n",
+    "!{sys.executable} -m pip install -q -r ../requirements/core.txt\n",
+    "\n",
+    "from harmony import BBox, Client, Collection, Request, Environment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "harmony_client = Client(env=Environment.UAT)  # assumes .netrc usage\n",
+    "\n",
+    "collection = Collection(id='C1234088182-EEDTEST')\n",
+    "request = Request(\n",
+    "    collection=collection,\n",
+    "    max_results=101\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# submit an async request for processing and return the job_id\n",
+    "# big requests get automatically paused after generating a preview of the results\n",
+    "job_id = harmony_client.submit(request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# checking the status of the job we see that it is 'paused'\n",
+    "harmony_client.status(job_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 'wait_for_processing()'\n",
+    "# warns that the job is paused before exiting\n",
+    "harmony_client.wait_for_processing(job_id, show_progress=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 'result_json()' will not wait for paused jobs and just returns any available results.\n",
+    "results = harmony_client.download_all(job_id, directory='/tmp', overwrite=True)\n",
+    "count = 0\n",
+    "for r in results:\n",
+    "    count += 1\n",
+    "print(f'Got {count} results')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# we can resume the job with 'resume()'\n",
+    "harmony_client.resume(job_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# checking the status we see that the job is running again\n",
+    "harmony_client.status(job_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# we can pause the job with 'pause()'.\n",
+    "harmony_client.pause(job_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# checking the status we see that the job is paused again\n",
+    "harmony_client.status(job_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We can resume the job again\n",
+    "harmony_client.resume(job_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 'wait_for_processing()' will show resumed progress\n",
+    "harmony_client.wait_for_processing(job_id, show_progress=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 'download_all()' now has access to the full results\n",
+    "results = harmony_client.download_all(job_id, directory='/tmp', overwrite=True)\n",
+    "count = 0\n",
+    "for r in results:\n",
+    "    count += 1\n",
+    "print(f'Got {count} results')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/job_pause_resume.ipynb
+++ b/examples/job_pause_resume.ipynb
@@ -65,9 +65,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# 'wait_for_processing()'\n",
+    "# 'wait_for_processing()' will wait will the job is in the 'previewing' state then\n",
     "# warns that the job is paused before exiting\n",
     "harmony_client.wait_for_processing(job_id, show_progress=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# checking the status we see that the job is paused\n",
+    "harmony_client.status(job_id)"
    ]
   },
   {
@@ -163,7 +173,68 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Attempting to pause a completed job will result in an error\n",
+    "harmony_client.pause(job_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Attempting to resume a completed job will also result in an error\n",
+    "harmony_client.resume(job_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# we can use the 'skip_preview' parameter to tell Harmony to skip the auto-pause/preview and just start running\n",
+    "harmony_client = Client(env=Environment.UAT)  # assumes .netrc usage\n",
+    "\n",
+    "collection = Collection(id='C1234088182-EEDTEST')\n",
+    "request = Request(\n",
+    "    collection=collection,\n",
+    "    max_results=101,\n",
+    "    skip_preview=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# submit an async request for processing and return the job_id\n",
+    "# big requests get automatically paused after generating a preview of the results\n",
+    "job_id = harmony_client.submit(request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# checking the status we see that the job is running\n",
+    "harmony_client.status(job_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# we can now use'wait_for_processing()' to wait until the job completes\n",
+    "harmony_client.wait_for_processing(job_id, show_progress=True)"
+   ]
   }
  ],
  "metadata": {

--- a/examples/job_pause_resume.ipynb
+++ b/examples/job_pause_resume.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,28 +51,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'status': 'previewing',\n",
-       " 'message': 'The job is generating a preview before auto-pausing. CMR query identified 176 granules, but the request has been limited to process only the first 101 granules because you requested 101 maxResults.',\n",
-       " 'progress': 0,\n",
-       " 'created_at': datetime.datetime(2022, 5, 6, 16, 56, 6, 792000, tzinfo=tzutc()),\n",
-       " 'updated_at': datetime.datetime(2022, 5, 6, 16, 56, 7, 356000, tzinfo=tzutc()),\n",
-       " 'created_at_local': '2022-05-06T12:56:06-04:00',\n",
-       " 'updated_at_local': '2022-05-06T12:56:07-04:00',\n",
-       " 'request': 'https://harmony.uat.earthdata.nasa.gov/C1234088182-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=true&maxResults=101',\n",
-       " 'num_input_granules': 101}"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# checking the status of the job we see that it is 'paused'\n",
     "harmony_client.status(job_id)"
@@ -80,19 +61,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      " [ Processing:   0% ] |                                                   | [\\]\n",
-      "Job has been paused.\n",
-      " [ Processing: 100% ] |###################################################| [|]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# 'wait_for_processing()' will wait will the job is in the 'previewing' state then\n",
     "# warns that the job is paused before exiting\n",

--- a/examples/job_pause_resume.ipynb
+++ b/examples/job_pause_resume.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,9 +51,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'status': 'previewing',\n",
+       " 'message': 'The job is generating a preview before auto-pausing. CMR query identified 176 granules, but the request has been limited to process only the first 101 granules because you requested 101 maxResults.',\n",
+       " 'progress': 0,\n",
+       " 'created_at': datetime.datetime(2022, 5, 6, 16, 56, 6, 792000, tzinfo=tzutc()),\n",
+       " 'updated_at': datetime.datetime(2022, 5, 6, 16, 56, 7, 356000, tzinfo=tzutc()),\n",
+       " 'created_at_local': '2022-05-06T12:56:06-04:00',\n",
+       " 'updated_at_local': '2022-05-06T12:56:07-04:00',\n",
+       " 'request': 'https://harmony.uat.earthdata.nasa.gov/C1234088182-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=true&maxResults=101',\n",
+       " 'num_input_granules': 101}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# checking the status of the job we see that it is 'paused'\n",
     "harmony_client.status(job_id)"
@@ -61,9 +80,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " [ Processing:   0% ] |                                                   | [\\]\n",
+      "Job has been paused.\n",
+      " [ Processing: 100% ] |###################################################| [|]\n"
+     ]
+    }
+   ],
    "source": [
     "# 'wait_for_processing()' will wait will the job is in the 'previewing' state then\n",
     "# warns that the job is paused before exiting\n",

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -607,7 +607,7 @@ class Client:
             return {
                 'status': status_subset['status'],
                 'message': status_subset['message']
-                    .replace(' The job may be resumed using the provided link.', ''),
+                .replace(' The job may be resumed using the provided link.', ''),
                 'progress': status_subset['progress'],
                 'created_at': created_at_dt,
                 'updated_at': updated_at_dt,
@@ -657,7 +657,6 @@ class Client:
             raise Exception(response.reason, message)
         else:
             response.raise_for_status()
-        
 
     def progress(self, job_id: str) -> Tuple[int, str, str]:
         """Retrieve a submitted job's completion status in percent.

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -710,7 +710,7 @@ class Client:
                         print('Job has been canceled.')
                         break
                     if status == 'paused':
-                        print('Job has been paused.')
+                        print('\nJob has been paused.', file=sys.stderr)
                         break
                     # This gets around an issue with progressbar. If we update() with 0, the
                     # output shows up as "N/A". If we update with, e.g. 0.1, it rounds down or

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -652,7 +652,7 @@ class Client:
         session = self._session()
         response = session.get(self._resume_url(job_id))
         if response.status_code == 409:
-            # 409 means we could not pause - the json will have a reason
+            # 409 means we could not resume - the json will have a reason
             message = response.json().get('description')
             raise Exception(response.reason, message)
         else:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -470,6 +470,25 @@ def test_pause():
     assert urllib.parse.unquote(responses.calls[0].request.url) == expected_pause_url(job_id)
 
 @responses.activate
+def test_pause_conflict_error():
+    job_id = '21469294-d6f7-42cc-89f2-c81990a5d7f4'
+    exp_json = {
+        'code': 'harmony.ConflictError',
+        'description': 'Error: Job status cannot be updated from successful to paused.'
+    }
+
+    responses.add(
+        responses.GET,
+        expected_pause_url(job_id),
+        status=409,
+        json = exp_json
+    )
+
+    with pytest.raises(Exception) as e:
+        Client(should_validate_auth=False).pause(job_id)
+    assert str(e.value) == "('Conflict', 'Error: Job status cannot be updated from successful to paused.')"
+
+@responses.activate
 def test_resume():
     collection = Collection(id='C333666999-EOSDIS')
     job_id = '21469294-d6f7-42cc-89f2-c81990a5d7f4'
@@ -486,6 +505,25 @@ def test_resume():
     assert len(responses.calls) == 1
     assert responses.calls[0].request is not None
     assert urllib.parse.unquote(responses.calls[0].request.url) == expected_resume_url(job_id)
+
+@responses.activate
+def test_resume_conflict_error():
+    job_id = '21469294-d6f7-42cc-89f2-c81990a5d7f4'
+    exp_json = {
+        'code': 'harmony.ConflictError',
+        'description': 'Error: Job status is running - only paused jobs can be resumed.'
+    }
+
+    responses.add(
+        responses.GET,
+        expected_resume_url(job_id),
+        status=409,
+        json = exp_json
+    )
+
+    with pytest.raises(Exception) as e:
+        Client(should_validate_auth=False).resume(job_id)
+    assert str(e.value) == "('Conflict', 'Error: Job status is running - only paused jobs can be resumed.')"
 
 @pytest.mark.parametrize('show_progress', [
     (True),

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -28,9 +28,9 @@ def test_request_with_skip_preview_true():
     assert request.is_valid()
     assert request.skip_preview is not None and request.skip_preview == True
 
-def test_request_defaults_to_skip_preview_true():
+def test_request_defaults_to_skip_preview_false():
     request = Request(collection=Collection('foobar'))
-    assert request.skip_preview
+    assert not request.skip_preview
 
 @settings(max_examples=200)
 @given(west=st.floats(allow_infinity=True),


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1135

## Description
Adds pause/resume to harmony-py and switches the `skip-preview` flag from defaulting to sending `skipPreview=true` to not setting the flag at all (preview will happen by default).

## Local Test Steps
Run `make examples` and then step through the `job_pause_resume.ipynb` notebook.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)