### PR TITLE
HARMONY-790: Add parsing of data expiratino from job status and STAC …

### DIFF
--- a/examples/job_results.ipynb
+++ b/examples/job_results.ipynb
@@ -148,7 +148,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/examples/job_stac.ipynb
+++ b/examples/job_stac.ipynb
@@ -37,7 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "harmony_client = Client(env=Environment.UAT)  # assumes .netrc usage\n",
+    "    harmony_client = Client(env=Environment.UAT)  # assumes .netrc usage\n",
     "\n",
     "collection = Collection(id='C1234088182-EEDTEST')\n",
     "request = Request(\n",

--- a/examples/job_stac.ipynb
+++ b/examples/job_stac.ipynb
@@ -42,7 +42,8 @@
     "collection = Collection(id='C1234088182-EEDTEST')\n",
     "request = Request(\n",
     "    collection=collection,\n",
-    "    spatial=BBox(-165, 52, -140, 77)\n",
+    "    spatial=BBox(-165, 52, -140, 77),\n",
+    "    max_results=5\n",
     ")\n",
     "\n",
     "job_id = harmony_client.submit(request)\n",
@@ -84,7 +85,7 @@
     "\n",
     "def requests_read_method(uri):\n",
     "    parsed = urlparse(uri)\n",
-    "    if parsed.hostname.startswith('harmony.'):\n",
+    "    if parsed.hostname.startswith('harmony.') or parsed.hostname.startswith('localhost'):\n",
     "        return harmony_client.read_text(uri)\n",
     "    else:\n",
     "        return STAC_IO.default_read_text_method(uri)\n",
@@ -99,12 +100,11 @@
    "outputs": [],
    "source": [
     "from pystac import Catalog\n",
-    "\n",
     "cat = Catalog.from_file(stac_catalog_url)\n",
     "\n",
     "print(cat.title)\n",
     "for item in cat.get_all_items():\n",
-    "    print(item.datetime, [asset.href for asset in item.assets.values()])"
+    "    print(item.datetime, item.properties.get('expires'), [asset.href for asset in item.assets.values()])"
    ]
   },
   {
@@ -131,7 +131,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/examples/job_stac.ipynb
+++ b/examples/job_stac.ipynb
@@ -94,6 +94,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For each STAC item in the catalog list its date, when it expires, and its access url"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/examples/job_status.ipynb
+++ b/examples/job_status.ipynb
@@ -80,7 +80,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -598,7 +598,7 @@ class Client:
         response = session.get(self._status_url(job_id))
         if response.ok:
             fields = [
-                'status', 'message', 'progress', 'createdAt', 'updatedAt', 'dataExpiration', 
+                'status', 'message', 'progress', 'createdAt', 'updatedAt', 'dataExpiration',
                 'request', 'numInputGranules'
             ]
             status_subset = {k: v for k, v in response.json().items() if k in fields}
@@ -615,7 +615,8 @@ class Client:
                 'created_at_local': created_at_dt.replace(microsecond=0).astimezone().isoformat(),
                 'updated_at_local': updated_at_dt.replace(microsecond=0).astimezone().isoformat(),
                 'data_expiration': data_expiration_dt,
-                'data_expiration_local': data_expiration_dt.replace(microsecond=0).astimezone().isoformat(),
+                'data_expiration_local': data_expiration_dt.
+                replace(microsecond=0).astimezone().isoformat(),
                 'request': status_subset['request'],
                 'num_input_granules': int(status_subset['numInputGranules']),
             }

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -20,7 +20,7 @@ import platform
 import requests.models
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import date, datetime
 from enum import Enum
 from typing import Any, ContextManager, IO, List, Mapping, NamedTuple, Optional, Tuple, Generator
 
@@ -598,12 +598,13 @@ class Client:
         response = session.get(self._status_url(job_id))
         if response.ok:
             fields = [
-                'status', 'message', 'progress', 'createdAt', 'updatedAt', 'request',
-                'numInputGranules'
+                'status', 'message', 'progress', 'createdAt', 'updatedAt', 'dataExpiration', 
+                'request', 'numInputGranules'
             ]
             status_subset = {k: v for k, v in response.json().items() if k in fields}
             created_at_dt = dateutil.parser.parse(status_subset['createdAt'])
             updated_at_dt = dateutil.parser.parse(status_subset['updatedAt'])
+            data_expiration_dt = dateutil.parser.parse(status_subset['dataExpiration'])
             return {
                 'status': status_subset['status'],
                 'message': status_subset['message']
@@ -613,6 +614,8 @@ class Client:
                 'updated_at': updated_at_dt,
                 'created_at_local': created_at_dt.replace(microsecond=0).astimezone().isoformat(),
                 'updated_at_local': updated_at_dt.replace(microsecond=0).astimezone().isoformat(),
+                'data_expiration': data_expiration_dt,
+                'data_expiration_local': data_expiration_dt.replace(microsecond=0).astimezone().isoformat(),
                 'request': status_subset['request'],
                 'num_input_granules': int(status_subset['numInputGranules']),
             }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -77,6 +77,7 @@ def expected_job(collection_id, job_id, link_type: LinkType = LinkType.https, ex
         'progress': 0,
         'createdAt': '2021-02-19T18:47:31.291Z',
         'updatedAt': '2021-02-19T18:47:31.291Z',
+        'dataExpiration': '2021-03-21T18:47:31.291Z',
         'links': [
             {
                 'title': 'Job Status',
@@ -412,8 +413,10 @@ def test_status():
         'progress': exp_job['progress'],
         'created_at': dateutil.parser.parse(exp_job['createdAt']),
         'updated_at': dateutil.parser.parse(exp_job['updatedAt']),
+        'data_expiration': dateutil.parser.parse(exp_job['dataExpiration']),
         'created_at_local': dateutil.parser.parse(exp_job['createdAt']).replace(microsecond=0).astimezone().isoformat(),
         'updated_at_local': dateutil.parser.parse(exp_job['updatedAt']).replace(microsecond=0).astimezone().isoformat(),
+        'data_expiration_local': dateutil.parser.parse(exp_job['dataExpiration']).replace(microsecond=0).astimezone().isoformat(),
         'request': exp_job['request'],
         'num_input_granules': exp_job['numInputGranules']}
     responses.add(


### PR DESCRIPTION
…items

## Jira Issue ID
HARMONY-790

## Description
Adds support for accessing data expiration date in job status response and STAC items

## Local Test Steps
* Run Harmony branch `harmony-790-expiration-dates`
* Run `make examples` in this rep
* Change `env=Environment.UAT` to `env=Environment.LOCAL` in job_stac.ipynb and job_status.ipynb (or job_results.ipynb)
* Execute those notebooks and verify that you see the expiration dates in the job status and STAC items 

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)