### PR TITLE
HARMONY-1124: Add support for setting dimension subsetting parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,7 +131,7 @@ dmypy.json
 .vscode/
 
 # Notebook generated files
-examples/*.nc.tif
+examples/*.tif
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/

--- a/harmony/__init__.py
+++ b/harmony/__init__.py
@@ -2,5 +2,5 @@
 __version__ = "0.4.1"
 
 from harmony.config import Environment
-from harmony.harmony import BBox, Client, Collection, LinkType, Request
+from harmony.harmony import BBox, Client, Collection, LinkType, Request, Dimension
 from harmony.util import s3_components

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -107,6 +107,7 @@ class BBox(NamedTuple):
     def __repr__(self) -> str:
         return f'BBox: West:{self.w}, South:{self.s}, East:{self.e}, North:{self.n}'
 
+
 class Dimension:
     """An arbitrary dimension to subset against. A dimension can take a minimum value and a
     maximum value to to subset against.
@@ -287,7 +288,7 @@ class Request:
         ]
         self.dimension_validations = [
             (lambda dim: dim.min is None or dim.max is None or dim.min <= dim.max,
-             (f'Dimension minimum value must be less than or equal to the maximum value'))
+             ('Dimension minimum value must be less than or equal to the maximum value'))
         ]
 
     def parameter_values(self) -> List[Tuple[str, Any]]:
@@ -424,8 +425,8 @@ class Client:
         params = {'forceAsync': 'true'}
 
         subset = self._spatial_subset_params(request) + \
-                 self._temporal_subset_params(request) + \
-                 self._dimension_subset_params(request)
+            self._temporal_subset_params(request) + \
+            self._dimension_subset_params(request)
 
         if len(subset) > 0:
             params['subset'] = subset


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1124

## Description
Add support for setting dimension subsetting parameters.

## Local Test Steps
Figure out how to test a Jupyter notebook with the code for this branch loaded 😱 .
Open the intro_tutorial notebook and modify the request that it sends with:
```
request = Request(
    collection=Collection(id='C1222931739-GHRC_CLOUD'),
    variables=['atmosphere_cloud_liquid_water_content'],
    format='application/netcdf',
    max_results=1,
    dimensions=[Dimension(name='foo', min=15.1, max=30),
                Dimension(name='bar', min=-120, max=120),
                Dimension(name='baz', min=-120),
                Dimension(name='bear'),
                Dimension(name='apple', max=5.5),
#                 Dimension(name='bad', min=1, max=-1),
                Dimension('arg'),
                Dimension('lev', 10.0, 20.0)]
)
```
Note you'll also have to modify the harmony imports to include Dimension:

```
from harmony import BBox, Client, Collection, Request, Dimension
```

Uncomment the one line to test `is_valid` throws an error if min is greater than max.
Otherwise submit the request and make sure that it completes successfully.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)