### PR TITLE
HARMONY-1125 - Allow dimensions to specify dim.min=0 or dim.max=0.

### DIFF
--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -515,9 +515,9 @@ class Client:
         if request.dimensions and len(request.dimensions) > 0:
             dimensions = []
             for dim in request.dimensions:
-                min = dim.min or '*'
-                max = dim.max or '*'
-                dim_query_param = [f'{dim.name}({min}:{max})']
+                dim_min = dim.min if dim.min is not None else '*'
+                dim_max = dim.max if dim.max is not None else '*'
+                dim_query_param = [f'{dim.name}({dim_min}:{dim_max})']
                 dimensions.append(dim_query_param)
             return dimensions
         else:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -48,10 +48,10 @@ def expected_full_submit_url(request):
     dimension_params = []
     if request.dimensions:
         for dim in request.dimensions:
-          name = dim.name
-          min = dim.min or '*'
-          max = dim.max or '*'
-          dimension_params += [f'subset={name}({min}:{max})']
+            name = dim.name
+            min = dim.min if dim.min is not None else '*'
+            max = dim.max if dim.max is not None else '*'
+            dimension_params += [f'subset={name}({min}:{max})']
 
     query_params = '&'.join(async_params + spatial_params + temporal_params + dimension_params)
     if request.format is not None:
@@ -216,18 +216,20 @@ def test_with_single_dimension():
         responses.calls[0].request.url) == expected_full_submit_url(request)
     assert actual_job_id == job_id
 
+
 @responses.activate
 def test_with_multiple_dimensions():
     collection = Collection(id='C1940468263-POCLOUD')
     request = Request(
         collection=collection,
         dimensions=[
-          Dimension('foo', 0, 20.5),
-          Dimension(name='bar', max=20.1, min=-10.2),
-          Dimension('baz'),
-          Dimension('alpha', -10),
-          Dimension('bravo', max=30),
-          Dimension('charlie', min=20),
+            Dimension('foo', None, 20.5),
+            Dimension(name='bar', max=20.1, min=-10.2),
+            Dimension('baz'),
+            Dimension('alpha', -10),
+            Dimension('bravo', max=30),
+            Dimension('charlie', min=20),
+            Dimension('delta', 0, 20.5),
         ]
     )
     job_id = '21469294-d6f7-42cc-89f2-c81990a5d7f4'


### PR DESCRIPTION
## Jira Issue ID

HARMONY-1125

## Description

Users may specify a dimension range with a minimum or maximum value that is 0. Prior to this change, when the request URL was constructed, there was a check for whether the minimum and maximum were falsy. If so, the value was assumed to mean `'*'`. However, 0 will also evaluate to `False`, meaning `Dimension('dim', 0, 10)` creates a subset parameter of `subset=dim(*:10)`, instead of `subset=dim(0:10)`. This PR addresses this edge-case.

## Local Test Steps

With the updated version of `harmony-py` create a request such as:

```python
from harmony import Client, Collection, Dimension, Environment, Request

harmony_client = Client(env=Environment.UAT)

hoss_named_dims_request = Request(collection=Collection(id='C1238392622-EEDTEST'),
                                  granule_id='G1245840464-EEDTEST',
                                  variables=['atmosphere_cloud_liquid_water_content'],
                                  dimensions=[Dimension('latitude', 0, 15),
                                              Dimension('longitude', -150, -105)])

harmony_client.submit(hoss_named_dims_request)
```
This should create a request URL that contains `subset=latitude(0:15)`, not `subset=latitude(*:15)`.

Note - this is mainly just to test named dimensions work with HOSS, I appreciate that `BBox` would normally be used in this example.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)