### PR TITLE
Harmony 784 - harmony-py should raise the error message contained in the harmony response body when possible

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,10 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: '0'
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.8'
     - shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,10 +10,10 @@ jobs:
         python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -26,7 +26,7 @@ jobs:
         make ci
 
     - name: Archive code coverage results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: code-coverage-report
         path: htmlcov/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -619,13 +619,13 @@ class Client:
             exception_message = None
             try:
                 response_json = response.json()
-                exception_message = response_json.get('reason')
+                exception_message = response_json.get('description')
                 if not exception_message:
-                    exception_message = response_json.get('message')
+                    exception_message = response_json.get('error')
             except:
                 pass
             if exception_message:
-                raise Exception(exception_message)
+                raise Exception(response.reason, exception_message)
         response.raise_for_status()
 
     def request_as_curl(self, request: Request) -> str:

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -671,7 +671,7 @@ class Client:
         if response.ok:
             job_id = (response.json())['jobID']
         else:
-            response.raise_for_status()
+            self._handle_error_response(response)
 
         return job_id
 
@@ -715,7 +715,7 @@ class Client:
                 'num_input_granules': int(status_subset['numInputGranules']),
             }
         else:
-            response.raise_for_status()
+            self._handle_error_response(response)
 
     def pause(self, job_id: str):
         """Pause a job.
@@ -776,7 +776,7 @@ class Client:
             json = response.json()
             return int(json['progress']), json['status'], json['message']
         else:
-            response.raise_for_status()
+            self._handle_error_response(response)
 
     def wait_for_processing(self, job_id: str, show_progress: bool = False) -> None:
         """Retrieve a submitted job's completion status in percent.

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -623,9 +623,6 @@ class Client:
         Args:
             response: The Response from Harmony
 
-        Returns:
-            An equivalent curl command as based on this client and request.
-
         Raises:
             Exception with a Harmony error message or a more generic
             HTTPError

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -616,6 +616,20 @@ class Client:
         return prepped_request
 
     def _handle_error_response(self, response: Response):
+        """Raises the appropriate exception based on the response
+        received from Harmony. Trys to pull out an error message
+        from a Harmony JSON response when possible.
+
+        Args:
+            response: The Response from Harmony
+
+        Returns:
+            An equivalent curl command as based on this client and request.
+
+        Raises:
+            Exception with a Harmony error message or a more generic
+            HTTPError
+        """
         if 'application/json' in response.headers.get('Content-Type', ''):
             exception_message = None
             try:

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -19,6 +19,7 @@ import sys
 from tabnanny import check
 import time
 import platform
+from requests import Response
 import requests.models
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager
@@ -612,6 +613,20 @@ class Client:
                 prepped_request = session.prepare_request(r)
 
         return prepped_request
+
+    def _handle_error_response(response: Response):
+        if 'application/json' in response.headers.get('Content-Type', ''):
+            exception_message = None
+            try:
+                response_json = response.json()
+                exception_message = response_json.get('reason')
+                if not exception_message:
+                    exception_message = response_json.get('message')
+            except:
+                pass
+            if exception_message:
+                raise Exception(exception_message)
+        response.raise_for_status()
 
     def request_as_curl(self, request: Request) -> str:
         """Returns a curl command representation of the given request.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,7 @@
 autopep8 ~= 1.4
 camel-case-switcher ~= 2.0
 coverage ~= 5.4
-flake8 ~= 3.8
+flake8 ~= 5.0.4
 hypothesis ~= 6.2
 mypy ~= 0.812
 m2r2 ~= 0.2

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1108,6 +1108,160 @@ def test_read_text(mocker):
 
     assert actual_text == expected_text
 
+@responses.activate
+def test_handle_error_response_with_description_key():
+    job_id = '3141592653-abcd-1234'
+    collection = Collection(id='C1940468263-POCLOUD')
+    request = Request(
+        collection=collection,
+        spatial=BBox(-107, 40, -105, 42)
+    )
+    error = { 'code': 'harmony.ServerError', 'description': 'Error: Harmony had an internal issue.' }
+    responses.add(
+        responses.GET,
+        expected_submit_url(collection.id),
+        status=500,
+        json=error
+    )
+    responses.add(
+        responses.GET,
+        expected_status_url(job_id),
+        status=500,
+        json=error
+    )
+    responses.add(
+        responses.GET,
+        expected_status_url(job_id),
+        status=500,
+        json=error
+    )
+    with pytest.raises(Exception) as e:
+        Client(should_validate_auth=False).submit(request)
+    assert str(e.value) == f"('Internal Server Error', '{error['description']}')"
+
+    with pytest.raises(Exception) as e:
+        Client(should_validate_auth=False).status(job_id)
+    assert str(e.value) == f"('Internal Server Error', '{error['description']}')"
+
+    with pytest.raises(Exception) as e:
+        Client(should_validate_auth=False).progress(job_id)
+    assert str(e.value) == f"('Internal Server Error', '{error['description']}')"
+
+
+@responses.activate
+def test_handle_error_response_no_description_key():
+    job_id = '3141592653-abcd-1234'
+    collection = Collection(id='C1940468263-POCLOUD')
+    request = Request(
+        collection=collection,
+        spatial=BBox(-107, 40, -105, 42)
+    )
+    error = { 'unrecognizable_key': 'Some information.' }
+    responses.add(
+        responses.GET,
+        expected_submit_url(collection.id),
+        status=500,
+        json=error
+    )
+    responses.add(
+        responses.GET,
+        expected_status_url(job_id),
+        status=500,
+        json=error
+    )
+    responses.add(
+        responses.GET,
+        expected_status_url(job_id),
+        status=500,
+        json=error
+    )
+    with pytest.raises(Exception) as e:
+        Client(should_validate_auth=False).submit(request)
+    assert "500 Server Error: Internal Server Error for url" in str(e.value)
+
+    with pytest.raises(Exception) as e:
+        Client(should_validate_auth=False).status(job_id)
+    assert "500 Server Error: Internal Server Error for url" in str(e.value)
+
+    with pytest.raises(Exception) as e:
+        Client(should_validate_auth=False).progress(job_id)
+    assert "500 Server Error: Internal Server Error for url" in str(e.value)
+
+@responses.activate
+def test_handle_error_response_no_json():
+    job_id = '3141592653-abcd-1234'
+    collection = Collection(id='C1940468263-POCLOUD')
+    request = Request(
+        collection=collection,
+        spatial=BBox(-107, 40, -105, 42)
+    )
+    responses.add(
+        responses.GET,
+        expected_submit_url(collection.id),
+        status=500,
+        body='error'
+    )
+    responses.add(
+        responses.GET,
+        expected_status_url(job_id),
+        status=500,
+        body='error'
+    )
+    responses.add(
+        responses.GET,
+        expected_status_url(job_id),
+        status=500,
+        body='error'
+    )
+    with pytest.raises(Exception) as e:
+        Client(should_validate_auth=False).submit(request)
+    assert "500 Server Error: Internal Server Error for url" in str(e.value)
+
+    with pytest.raises(Exception) as e:
+        Client(should_validate_auth=False).status(job_id)
+    assert "500 Server Error: Internal Server Error for url" in str(e.value)
+
+    with pytest.raises(Exception) as e:
+        Client(should_validate_auth=False).progress(job_id)
+    assert "500 Server Error: Internal Server Error for url" in str(e.value)
+
+@responses.activate
+def test_handle_error_response_invalid_json():
+    job_id = '3141592653-abcd-1234'
+    collection = Collection(id='C1940468263-POCLOUD')
+    request = Request(
+        collection=collection,
+        spatial=BBox(-107, 40, -105, 42)
+    )
+    responses.add(
+        responses.GET,
+        expected_submit_url(collection.id),
+        status=500,
+        json='error'
+    )
+    responses.add(
+        responses.GET,
+        expected_status_url(job_id),
+        status=500,
+        json='error'
+    )
+    responses.add(
+        responses.GET,
+        expected_status_url(job_id),
+        status=500,
+        json='error'
+    )
+    with pytest.raises(Exception) as e:
+        Client(should_validate_auth=False).submit(request)
+    assert "500 Server Error: Internal Server Error for url" in str(e.value)
+
+    with pytest.raises(Exception) as e:
+        Client(should_validate_auth=False).status(job_id)
+    assert "500 Server Error: Internal Server Error for url" in str(e.value)
+
+    with pytest.raises(Exception) as e:
+        Client(should_validate_auth=False).progress(job_id)
+    assert "500 Server Error: Internal Server Error for url" in str(e.value)
 
 def test_request_as_curl_get():
     collection = Collection(id='C1940468263-POCLOUD')


### PR DESCRIPTION
## Jira Issue ID
HARMONY-784

## Description
harmony-py will now raise the error message contained in the harmony response body when possible.

The ticket specified that we should not use `response.raise_for_status()` when possible so I basically modified all the places that `response.raise_for_status()` was currently being used _and_ where we may receive a Harmony response, and replaced it with the new error helper function that attempts to pull out the harmony error message.

I also modified some github action versions to get rid of deprecation warnings. I will take a look at the other python repos to see if they need to be updated as well.

You may also be wondering why I had to write `if hasattr(response_json, 'get'):`. During testing I discovered that `response.json()` might return a string.

## Local Test Steps
Set up a virtual environment for harmony-py (in the root of your harmony-py directory). Also follow the steps in the readme to make sure that this branch's version of harmony-py is installed in the venv:
```
1. Install dependencies:

        $ make install

2. Optionally register your local copy with pip:

        $ pip install -e ./path/to/harmony_py
```
Run harmony locally and in your harmony code modify jobs.ts#getJobStatus or base-service.ts#invoke to throw a custom harmony error (from errors.ts).

Now try running harmony-py/examples/basic.ipynb which should fail on the cell that either submits the job or checks the status of the job (depending on where you put the exception in your harmony code). Check that the exception printed in your notebook includes the custom harmony message that you threw.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)