### PR TITLE
HARMONY-1215: Add destination url

### DIFF
--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -307,6 +307,10 @@ class Request:
             (lambda dim: dim.min is None or dim.max is None or dim.min <= dim.max,
              ('Dimension minimum value must be less than or equal to the maximum value'))
         ]
+        self.parameter_validations = [  # for simple, one-off validations
+            (True if self.destination_url is None else self.destination_url.startswith('s3://'),
+             ('Destination URL must be an S3 location'))
+        ]
 
     def parameter_values(self) -> List[Tuple[str, Any]]:
         """Returns tuples of each query parameter that has been set and its value."""
@@ -337,6 +341,7 @@ class Request:
         spatial_msgs = []
         temporal_msgs = []
         dimension_msgs = []
+        parameter_msgs = [m for v, m in self.parameter_validations if not v]
         shape_msgs = self._shape_error_messages(self.shape)
         if self.spatial:
             spatial_msgs = [m for v, m in self.spatial_validations if not v(self.spatial)]
@@ -348,7 +353,7 @@ class Request:
                 if msgs:
                     dimension_msgs += msgs
 
-        return spatial_msgs + temporal_msgs + shape_msgs + dimension_msgs
+        return spatial_msgs + temporal_msgs + shape_msgs + dimension_msgs + parameter_msgs
 
 
 class LinkType(Enum):

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -211,6 +211,9 @@ class Request:
         skip_preview: Whether Harmony should skip auto-pausing and generating a preview for
           large jobs
 
+        destination_url: Destination URL specified by the client
+          (only S3 is supported, e.g. s3://my-bucket-name/mypath)
+
     Returns:
         A Harmony Request instance
     """
@@ -222,6 +225,7 @@ class Request:
                  temporal: Mapping[str, datetime] = None,
                  dimensions: List[Dimension] = None,
                  crs: str = None,
+                 destination_url: str = None,
                  format: str = None,
                  granule_id: List[str] = None,
                  granule_name: List[str] = None,
@@ -242,6 +246,7 @@ class Request:
         self.temporal = temporal
         self.dimensions = dimensions
         self.crs = crs
+        self.destination_url = destination_url
         self.format = format
         self.granule_id = granule_id
         self.granule_name = granule_name
@@ -258,6 +263,7 @@ class Request:
 
         self.variable_name_to_query_param = {
             'crs': 'outputcrs',
+            'destination_url': 'destinationUrl',
             'interpolation': 'interpolation',
             'scale_extent': 'scaleExtent',
             'scale_size': 'scaleSize',

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -414,6 +414,7 @@ def test_post_request_has_user_agent_headers(examples_dir):
 
 @pytest.mark.parametrize('param,expected', [
     ({'crs': 'epsg:3141'}, 'outputcrs=epsg:3141'),
+    ({'destination_url': 's3://bucket'}, 'destinationUrl=s3://bucket'),
     ({'format': 'r2d2/hologram'}, 'format=r2d2/hologram'),
     ({'granule_id': ['G1', 'G2', 'G3']}, 'granuleId=G1&granuleId=G2&granuleId=G3'),
     ({'granule_name': ['abc*123', 'ab?d123', 'abcd123']}, 'granuleName=abc*123&granuleName=ab?d123&granuleName=abcd123'),

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -176,3 +176,10 @@ def test_request_shape_file_error_message(key, value, messages):
 
     assert not request.is_valid()
     assert request.error_messages() == messages
+
+def test_request_destination_url_error_message():
+    request = Request(Collection('foo'), destination_url='http://somesite.com')
+    messages = request.error_messages()
+
+    assert not request.is_valid()
+    assert 'Destination URL must be an S3 location' in messages


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1215

## Description
This adds the new destination URL parameter to the harmony-py client. I want to hold off on merging this until Harmony fully supports this parameter.

## Local Test Steps
Make a harmony-py request using the new parameter and check to make sure that destination URL was included in the request URL.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)