### PR TITLE
HARMONY-1355: Add UMM grid name parameter

### DIFF
--- a/examples/intro_tutorial.ipynb
+++ b/examples/intro_tutorial.ipynb
@@ -211,7 +211,7 @@
     "    variables=['science/grids/data/unwrappedPhase'],\n",
     "    format='image/tiff',\n",
     "    max_results=2,\n",
-    "    # if desired, deliver results to a custom destination bucket\n",
+    "    # If desired, deliver results to a custom destination bucket. Note the bucket must reside in AWS us-west-2 region.\n",
     "    # destination_url='s3://my-bucket'\n",
     ")"
    ]

--- a/examples/intro_tutorial.ipynb
+++ b/examples/intro_tutorial.ipynb
@@ -211,6 +211,8 @@
     "    variables=['science/grids/data/unwrappedPhase'],\n",
     "    format='image/tiff',\n",
     "    max_results=2,\n",
+    "    # if desired, deliver results to a custom destination bucket\n",
+    "    # destination_url='s3://my-bucket'\n",
     ")"
    ]
   },
@@ -569,6 +571,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# NOTE: if you specified destination_url you'll have to retrieve your credentials in another manner\n",
+    "# https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html\n",
     "creds = harmony_client.aws_credentials()\n",
     "creds"
    ]
@@ -636,7 +640,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
@@ -650,7 +654,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.9.2"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "bc748110a6ec18982109b2289f9c506ebfe86428d3e48ddecc746f3969e698e0"
+   }
   }
  },
  "nbformat": 4,

--- a/examples/s3_access.ipynb
+++ b/examples/s3_access.ipynb
@@ -84,6 +84,7 @@
     "results = harmony_client.result_urls(job_id, link_type=LinkType.s3)\n",
     "print(results)\n",
     "# NOTE: if you specified destination_url you'll have to retrieve your credentials in another manner\n",
+    "# https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html\n",
     "creds = harmony_client.aws_credentials()"
    ]
   },

--- a/examples/s3_access.ipynb
+++ b/examples/s3_access.ipynb
@@ -43,7 +43,9 @@
     "    crs='EPSG:3995',\n",
     "    format='image/tiff',\n",
     "    height=512,\n",
-    "    width=512\n",
+    "    width=512,\n",
+    "    # if desired, deliver results to a custom destination bucket\n",
+    "    # destination_url='s3://my-bucket' \n",
     ")\n",
     "\n",
     "request.is_valid()"
@@ -81,6 +83,7 @@
    "source": [
     "results = harmony_client.result_urls(job_id, link_type=LinkType.s3)\n",
     "print(results)\n",
+    "# NOTE: if you specified destination_url you'll have to retrieve your credentials in another manner\n",
     "creds = harmony_client.aws_credentials()"
    ]
   },
@@ -113,7 +116,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
@@ -127,7 +130,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.9.2"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "bc748110a6ec18982109b2289f9c506ebfe86428d3e48ddecc746f3969e698e0"
+   }
   }
  },
  "nbformat": 4,

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -177,7 +177,7 @@
    "id": "45a14473",
    "metadata": {},
    "source": [
-    "We can also specify a grid using the UMM grid name from the CMR. Let's build another request. This time, we'll request a specific granule and grid."
+    "Let's build another request. This time, we'll request a specific granule and grid using the UMM grid name from the CMR. You can find grids in the CMR at https://cmr.uat.earthdata.nasa.gov/search/grids.umm_json. Include a query parameter `?name=LambertExample` to list detailed information about a specific grid."
    ]
   },
   {

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -193,7 +193,7 @@
     "    collection=collection,\n",
     "    granule_id='G1233860486-EEDTEST',\n",
     "    interpolation='near',\n",
-    "    grid='LambertDurbin'\n",
+    "    grid='LambertExample'\n",
     ")\n",
     "\n",
     "request.is_valid()"

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -29,6 +29,9 @@
     "from IPython.display import display, JSON\n",
     "import rasterio\n",
     "import rasterio.plot\n",
+    "import netCDF4 as nc4\n",
+    "from matplotlib import pyplot as plt\n",
+    "import numpy as np\n",
     "\n",
     "from harmony import BBox, Client, Collection, Request, Environment"
    ]
@@ -52,11 +55,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "mental-marble",
    "metadata": {},
    "source": [
-    "Next, let's create a Collection object with the CMR collection id for the CMR collection we'd like to look at.\n",
+    "Next, let's create a Collection object with the [CMR](https://cmr.earthdata.nasa.gov/) collection id for the CMR collection we'd like to look at.\n",
     "\n",
     "We then create a Request which specifies that collection, a `spatial` `BBox` describing the bounding box for the area we're interested in (we'll look at the ``BBox`` in other tutorials). In this case we're interested in looking at Alaska (and who wouldn't be?). We also include a date/time range to narrow down the data.\n",
     "\n",
@@ -166,11 +170,84 @@
     "for r in results:\n",
     "    rasterio.plot.show(rasterio.open(r.result()))"
    ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "45a14473",
+   "metadata": {},
+   "source": [
+    "We can also specify a grid using the UMM grid name from the CMR. Let's build another request. This time, we'll request a specific granule and grid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6bead4b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collection = Collection(id='C1233860183-EEDTEST')\n",
+    "\n",
+    "request = Request(\n",
+    "    collection=collection,\n",
+    "    granule_id='G1233860486-EEDTEST',\n",
+    "    interpolation='near',\n",
+    "    grid='LambertDurbin'\n",
+    ")\n",
+    "\n",
+    "request.is_valid()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "5cb4496b",
+   "metadata": {},
+   "source": [
+    "Submit the job and check on the status."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3f030a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_id = harmony_client.submit(request)\n",
+    "JSON(harmony_client.status(job_id))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "d76b6104",
+   "metadata": {},
+   "source": [
+    "Download and  plot the file using pyplot and numpy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b182ee17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = harmony_client.download_all(job_id, directory='/tmp', overwrite=True)\n",
+    "nc4_file=nc4.Dataset(list(results)[0].result())\n",
+    "arrays = []\n",
+    "for var in ['red_var', 'green_var', 'blue_var', 'alpha_var']:\n",
+    "    ds = nc4_file.variables[var][0,:]\n",
+    "    arrays.append(ds)\n",
+    "plt.imshow(np.dstack(arrays))"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "venv",
    "language": "python",
    "name": "python3"
   },
@@ -184,7 +261,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.9.2"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "bc748110a6ec18982109b2289f9c506ebfe86428d3e48ddecc746f3969e698e0"
+   }
   }
  },
  "nbformat": 4,

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -214,6 +214,9 @@ class Request:
         destination_url: Destination URL specified by the client
           (only S3 is supported, e.g. s3://my-bucket-name/mypath)
 
+        grid: The name of the output grid to use for regridding requests. The name must
+          match the UMM grid name in the CMR.
+
     Returns:
         A Harmony Request instance
     """
@@ -238,7 +241,8 @@ class Request:
                  variables: List[str] = ['all'],
                  width: int = None,
                  concatenate: bool = None,
-                 skip_preview: bool = None):
+                 skip_preview: bool = None,
+                 grid: str = None):
         """Creates a new Request instance from all specified criteria.'
         """
         self.collection = collection
@@ -260,6 +264,7 @@ class Request:
         self.width = width
         self.concatenate = concatenate
         self.skip_preview = skip_preview
+        self.grid = grid
 
         self.variable_name_to_query_param = {
             'crs': 'outputcrs',
@@ -276,6 +281,7 @@ class Request:
             'max_results': 'maxResults',
             'concatenate': 'concatenate',
             'skip_preview': 'skipPreview',
+            'grid': 'grid',
         }
 
         self.spatial_validations = [

--- a/requirements/examples.txt
+++ b/requirements/examples.txt
@@ -7,3 +7,4 @@ pystac ~= 0.5
 rasterio ~= 1.2
 intake-stac ~= 0.3
 netCDF4
+numpy

--- a/requirements/examples.txt
+++ b/requirements/examples.txt
@@ -6,3 +6,4 @@ matplotlib ~= 3.3
 pystac ~= 0.5
 rasterio ~= 1.2
 intake-stac ~= 0.3
+netCDF4

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -425,6 +425,7 @@ def test_post_request_has_user_agent_headers(examples_dir):
     ({'scale_size': [1.0, 2.0]}, 'scaleSize=1.0,2.0'),
     ({'width': 100}, 'width=100'),
     ({'concatenate': True}, 'concatenate=true'),
+    ({'grid': 'theGridName'}, 'grid=theGridName'),
 ])
 @responses.activate
 def test_request_has_query_param(param, expected):


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1355

## Description
Adds the new UMM grid name parameter.

## Local Test Steps
After activating your virtual environment, `pip install -e .` to get this branch version of harmony-py in your virtual environment.
Run through notebooks/examples/basic.ipynb. Modify the request to pass in a grid name. E.g.:
```
collection = Collection(id='C1234088182-EEDTEST')

request = Request(
    collection=collection,
    spatial=BBox(-165, 52, -140, 77),
    grid='LambertDurbin'
)
```
Inspect the request URL after submitting the job: https://harmony.uat.earthdata.nasa.gov/workflow-ui -- you should see `&grid=`.

Add an invalid grid name if you want to see an error.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)