### PR TITLE
HARMONY-1376: Don't expect data expiration for every job status

### DIFF
--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -728,8 +728,8 @@ class Client:
             status_subset = {k: v for k, v in response.json().items() if k in fields}
             created_at_dt = dateutil.parser.parse(status_subset['createdAt'])
             updated_at_dt = dateutil.parser.parse(status_subset['updatedAt'])
-            data_expiration_dt = dateutil.parser.parse(status_subset['dataExpiration'])
-            return {
+
+            status_json = {
                 'status': status_subset['status'],
                 'message': status_subset['message']
                 .replace(' The job may be resumed using the provided link.', ''),
@@ -738,12 +738,16 @@ class Client:
                 'updated_at': updated_at_dt,
                 'created_at_local': created_at_dt.replace(microsecond=0).astimezone().isoformat(),
                 'updated_at_local': updated_at_dt.replace(microsecond=0).astimezone().isoformat(),
-                'data_expiration': data_expiration_dt,
-                'data_expiration_local': data_expiration_dt.
-                replace(microsecond=0).astimezone().isoformat(),
                 'request': status_subset['request'],
                 'num_input_granules': int(status_subset['numInputGranules']),
             }
+            if 'dataExpiration' in status_subset:
+                data_expiration_dt = dateutil.parser.parse(status_subset['dataExpiration'])
+                data_expiration_local = data_expiration_dt.replace(
+                    microsecond=0).astimezone().isoformat()
+                status_json['data_expiration'] = data_expiration_dt
+                status_json['data_expiration_local'] = data_expiration_local
+            return status_json
         else:
             self._handle_error_response(response)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -493,6 +493,10 @@ def test_status():
     )
 
     actual_status = Client(should_validate_auth=False).status(job_id)
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request is not None
+    assert urllib.parse.unquote(responses.calls[0].request.url) == expected_status_url(job_id)
     assert actual_status == expected_status
 
 @responses.activate
@@ -519,10 +523,6 @@ def test_status_no_key_error_on_missing_expiration():
     )
 
     actual_status = Client(should_validate_auth=False).status(job_id)
-
-    assert len(responses.calls) == 1
-    assert responses.calls[0].request is not None
-    assert urllib.parse.unquote(responses.calls[0].request.url) == expected_status_url(job_id)
     assert actual_status == expected_status
 
 @responses.activate

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -493,10 +493,6 @@ def test_status():
     )
 
     actual_status = Client(should_validate_auth=False).status(job_id)
-
-    assert len(responses.calls) == 1
-    assert responses.calls[0].request is not None
-    assert urllib.parse.unquote(responses.calls[0].request.url) == expected_status_url(job_id)
     assert actual_status == expected_status
 
 @responses.activate

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -499,6 +499,35 @@ def test_status():
     assert urllib.parse.unquote(responses.calls[0].request.url) == expected_status_url(job_id)
     assert actual_status == expected_status
 
+@responses.activate
+def test_status_no_key_error_on_missing_expiration():
+    collection = Collection(id='C333666999-EOSDIS')
+    job_id = '21469294-d6f7-42cc-89f2-c81990a5d7f4'
+    exp_job = expected_job(collection.id, job_id)
+    del exp_job['dataExpiration']
+    expected_status = {
+        'status': exp_job['status'],
+        'message': exp_job['message'],
+        'progress': exp_job['progress'],
+        'created_at': dateutil.parser.parse(exp_job['createdAt']),
+        'updated_at': dateutil.parser.parse(exp_job['updatedAt']),
+        'created_at_local': dateutil.parser.parse(exp_job['createdAt']).replace(microsecond=0).astimezone().isoformat(),
+        'updated_at_local': dateutil.parser.parse(exp_job['updatedAt']).replace(microsecond=0).astimezone().isoformat(),
+        'request': exp_job['request'],
+        'num_input_granules': exp_job['numInputGranules']}
+    responses.add(
+        responses.GET,
+        expected_status_url(job_id),
+        status=200,
+        json=exp_job
+    )
+
+    actual_status = Client(should_validate_auth=False).status(job_id)
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request is not None
+    assert urllib.parse.unquote(responses.calls[0].request.url) == expected_status_url(job_id)
+    assert actual_status == expected_status
 
 @responses.activate
 def test_progress():


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1376

## Description
This modifies the status method to check for a data expiration field rather than assuming that it exists. There are some cases, like when destination_url is passed where the expiration field will not be returned from harmony and thus cannot be returned to users of harmony-py.

## Local Test Steps
After activating your virtual environment, `pip install -e .` to get this branch version of harmony-py in your virtual environment.
Run through notebooks/examples/basic.ipynb. Modify the request to pass in a destination_url. E.g.:

```
collection = Collection(id='C1234088182-EEDTEST')

request = Request(
    collection=collection,
    spatial=BBox(-165, 52, -140, 77),
    destination_url='s3://my-bucket'
)
```
The request should succeed if your bucket has the proper settings, and the notebook cell that calls the job status function should not fail.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)