### PR TITLE
HARMONY-720: Added EDL token support in harmony-py.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Harmony-Py is a Python library for integrating with NASA's [Harmony](https://har
 
 Harmony-Py provides a Python alternative to directly using [Harmony's RESTful API](https://harmony.earthdata.nasa.gov/docs/api/). It handles NASA [Earthdata Login (EDL)](https://urs.earthdata.nasa.gov/home) authentication and optionally integrates with the [CMR Python Wrapper](https://github.com/nasa/eo-metadata-tools) by accepting collection results as a request parameter. It's convenient for scientists who wish to use Harmony from Jupyter notebooks as well as machine-to-machine communication with larger Python applications.
 
-Harmony-Py is a work-in-progress, is not feature complete, and should only be used if you would like to test its functionality. We welcome feedback on Harmony-Py via [GitHub Issues](https://github.com/nasa/harmony-py/issues)
+We welcome feedback on Harmony-Py via [GitHub Issues](https://github.com/nasa/harmony-py/issues)
 
 ![Python package](https://github.com/nasa/harmony-py/workflows/Python%20package/badge.svg)
 

--- a/examples/intro_tutorial.ipynb
+++ b/examples/intro_tutorial.ipynb
@@ -675,7 +675,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.7.16"
   },
   "vscode": {
    "interpreter": {

--- a/examples/intro_tutorial.ipynb
+++ b/examples/intro_tutorial.ipynb
@@ -37,7 +37,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ed97d7e6-795a-41d7-9025-3f5a9b360e34",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Install notebook requirements\n",
@@ -52,11 +54,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "16815631",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import datetime as dt\n",
     "from IPython.display import display, JSON\n",
+    "import os\n",
     "import rasterio\n",
     "import rasterio.plot\n",
     "\n",
@@ -105,15 +110,21 @@
     "\n",
     "First, you will need to create your Harmony Client, which is what you will interact with to submit and inspect a data request to Harmony, as well as to retrieve your results. \n",
     "\n",
-    "When creating the Client, you need to provide your [Earthdata Login](https://urs.earthdata.nasa.gov) credentials, which are required to access data from NASA EOSDIS. There are three options for providing your Earthdata Login username and password: \n",
+    "When creating the Client, you need to provide either your EDL token or your [Earthdata Login](https://urs.earthdata.nasa.gov) credentials, which are required to access data from NASA EOSDIS. There are four options for providing your Earthdata Login token or username and password when creating a Harmony Client: \n",
     "\n",
-    "1. Provide your username and password directly when creating the client:\n",
+    "1. Provide EDL token using environment variable:\n",
+    "\n",
+    "```\n",
+    "$ export EDL_TOKEN='my_eld_token'\n",
+    "```\n",
+    "\n",
+    "2. Provide your username and password directly when creating the client:\n",
     "\n",
     "```\n",
     "harmony_client = Client(auth=('captainmarvel', 'marve10u5'))\n",
     "```\n",
     "\n",
-    "2. Set your credentials using environment variables:\n",
+    "3. Set your credentials using environment variables:\n",
     "\n",
     "You can either export these directly: \n",
     "\n",
@@ -128,7 +139,7 @@
     "EDL_PASSWORD=mypass\n",
     "```\n",
     "\n",
-    "3. Use a .netrc file:\n",
+    "4. Use a .netrc file:\n",
     "\n",
     "Create a .netrc file in your home directory, using the example below:\n",
     "\n",
@@ -136,17 +147,27 @@
     "machine urs.earthdata.nasa.gov\n",
     "login captainmarvel\n",
     "password marve10u5\n",
-    "```"
+    "```\n",
+    "\n",
+    "The code below will create a Harmony Client using EDL token if the `EDL_TOKEN` envrionment variable is defined or use .netrc file if the `EDL_TOKEN` envrionment variable is not defined."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "710e9f40",
-   "metadata": {},
+   "id": "45bc3815-7f6c-4cc3-8ed0-c495468d5074",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "harmony_client = Client() # assumes .netrc usage, option 3 above"
+    "token = os.getenv('EDL_TOKEN')\n",
+    "if (token is None or token == ''):\n",
+    "    print('Use .netrc for client authentication')\n",
+    "    harmony_client = Client()\n",
+    "else:\n",
+    "    print('Use EDL token from the environment for client authentication')\n",
+    "    harmony_client = Client(token=token)"
    ]
   },
   {
@@ -640,7 +661,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -654,11 +675,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.10.9"
   },
   "vscode": {
    "interpreter": {
-    "hash": "bc748110a6ec18982109b2289f9c506ebfe86428d3e48ddecc746f3969e698e0"
+    "hash": "d0b323d74a2eccdefaacaf33c041ca03218ebb6c9aa84851ec587afd8a56d428"
    }
   }
  },

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -400,6 +400,7 @@ class Client:
         auth: Optional[Tuple[str, str]] = None,
         should_validate_auth: bool = True,
         env: Environment = Environment.PROD,
+        token: str = None,
         # How often to poll Harmony for updated information during job processing
         check_interval: float = 3.0  # in seconds
     ):
@@ -412,6 +413,7 @@ class Client:
         self.config = Config(env)
         self.session = None
         self.auth = auth
+        self.token = token
         self.check_interval = check_interval
 
         num_workers = int(self.config.NUM_REQUESTS_WORKERS)
@@ -423,7 +425,10 @@ class Client:
     def _session(self):
         """Creates (if needed) and returns the Client's requests Session."""
         if self.session is None:
-            self.session = create_session(self.config, self.auth)
+            if self.token:
+                self.session = create_session(self.config, token=self.token)
+            else:
+                self.session = create_session(self.config, auth=self.auth)
         return self.session
 
     def _submit_url(self, request: Request) -> str:


### PR DESCRIPTION
## Jira Issue ID
HARMONY-720

## Description
As a user, I want to authenticate to Harmony using the Python library with long-lived Earthdata Login tokens

## Local Test Steps
export EDL_TOKEN=<your_EDL_token>
Run `make examples` in harmony-py to start the notebooks
verify `examples/intro_tutorial.ipynb` notebook works.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)