### PR TITLE
Limit accepted encodings in _download_file

### DIFF
--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -1017,7 +1017,10 @@ class Client:
                 print(filename)
             return filename
         else:
-            with session.get(url, stream=True) as r:
+            headers = {
+                "Accept-Encoding": "identity"
+            }
+            with session.get(url, stream=True, headers=headers) as r:
                 with open(filename, 'wb') as f:
                     shutil.copyfileobj(r.raw, f, length=chunksize)
             if verbose and verbose.upper() == 'TRUE':


### PR DESCRIPTION

## Jira Issue ID
DAS-1606


## Description

This is a quick fix for gzipped files being downloaded with the incorrect extension.

slack discussion thread
https://nsidc.slack.com/archives/CLC2SR1S6/p1685051702665579


## Local Test Steps 

Pull this branch and install the library into a isolated python environment.
start a repl and run these commands:
``` python
from harmony import Environment, Client
harmony_client = Client(env=Environment.SIT)
theurl = 'https://harmony.sit.earthdata.nasa.gov/service-results/harmony-sit-staging/public/e8ae74fc-55f4-48c4-a94f-b9d0afe6cf9d/1513588/ASTGTMV003_N00E022_dem.jpg.aux.xml'
future = harmony_client.download(theurl, directory='.', overwrite=True)
print(future.result())

```

Ensure the downloaded file is in fact xml by opening it or running this command:
```sh
file ./ASTGTMV003_N00E022_dem.jpg.aux.xml
```

The output should be:
``` sh
./ASTGTMV003_N00E022_dem.jpg.aux.xml: ASCII text, with very long lines (346)
```



## PR Acceptance Checklist
* [ n/a ] Acceptance criteria met
* [ n/a ] Tests added/updated (if needed) and passing
* [ n/a ] Documentation updated (if needed)