### PR TITLE
Harmony 848 - Zarr output + download_all clarification

### DIFF
--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -411,6 +411,9 @@ class Client:
     disabled by passing ``should_validate_auth=False``.
     """
 
+    zarr_download_exception = Exception("The zarr library must be used for zarr files."
+                + "See https://github.com/nasa/harmony/blob/main/docs/Harmony%20Feature%20Examples.ipynb for zarr library usage example.")
+
     def __init__(
         self,
         *,
@@ -1041,6 +1044,8 @@ class Client:
         Returns:
             A Future that resolves to the full path to the file.
         """
+        if url.endswith('zarr'):
+            raise self.zarr_download_exception
         future = self.executor.submit(self._download_file, url, directory, overwrite)
         return future
 
@@ -1078,6 +1083,8 @@ class Client:
             result.
         """
         for url in self.result_urls(job_id, show_progress=False) or []:
+            if url.endswith('zarr'):
+                raise self.zarr_download_exception
             yield self.executor.submit(self._download_file, url, directory, overwrite)
 
     def iterator(

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -412,8 +412,8 @@ class Client:
     """
 
     zarr_download_exception_msg = 'The zarr library must be used for zarr files. '\
-    'See https://github.com/nasa/harmony/blob/main/docs/Harmony%20Feature%20Examples.ipynb '\
-    'for zarr library usage example.'
+        'See https://github.com/nasa/harmony/blob/main/docs/Harmony%20Feature%20Examples.ipynb '\
+        'for zarr library usage example.'
     zarr_download_exception = Exception(zarr_download_exception_msg)
 
     def __init__(

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -411,8 +411,10 @@ class Client:
     disabled by passing ``should_validate_auth=False``.
     """
 
-    zarr_download_exception = Exception("The zarr library must be used for zarr files."
-                + "See https://github.com/nasa/harmony/blob/main/docs/Harmony%20Feature%20Examples.ipynb for zarr library usage example.")
+    zarr_download_exception_msg = 'The zarr library must be used for zarr files. '\
+    'See https://github.com/nasa/harmony/blob/main/docs/Harmony%20Feature%20Examples.ipynb '\
+    'for zarr library usage example.'
+    zarr_download_exception = Exception(zarr_download_exception_msg)
 
     def __init__(
         self,


### PR DESCRIPTION
## Jira Issue ID
HARMONY-848

## Description
This pull request adds logic that throws an exception if a user attempts to download zarr file(s).

## Local Test Steps
- check out this branch
- download harmony-py in your virtual env `pip install -e path/to/local/harmony-py`
- make a harmony-py request and try download and download all (both should raise a zarr exception message):
```
from harmony import BBox, Client, Collection, Request, Environment

harmony_client = Client(auth=(username.value, password.value), env=Environment.UAT)

collection = Collection(id='C1234088182-EEDTEST')

request = Request(
    collection=collection,
    spatial=BBox(-165, 52, -140, 77),
    format='application/x-zarr',
    max_results=1,
)

job1_id = harmony_client.submit(request)

[f.result() for f in harmony_client.download_all(job1_id)]

harmony_client.download('s3://path/to/zarr-file') // get this file url from the job status page
```

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)