### PR TITLE
HARMONY-1568: Add extend param

### DIFF
--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -217,6 +217,8 @@ class Request(BaseRequest):
 
         dimensions: A list of dimensions to use for subsetting the data
 
+        extend: A list of dimensions to extend
+
         crs: reproject the output coverage to the given CRS.  Recognizes CRS types that can be
           inferred by gdal, including EPSG codes, Proj4 strings, and OGC URLs
           (http://www.opengis.net/def/crs/...)
@@ -267,6 +269,7 @@ class Request(BaseRequest):
                  spatial: BBox = None,
                  temporal: Mapping[str, datetime] = None,
                  dimensions: List[Dimension] = None,
+                 extend: List[str] = None,
                  crs: str = None,
                  destination_url: str = None,
                  format: str = None,
@@ -290,6 +293,7 @@ class Request(BaseRequest):
         self.spatial = spatial
         self.temporal = temporal
         self.dimensions = dimensions
+        self.extend = extend
         self.crs = crs
         self.destination_url = destination_url
         self.format = format
@@ -325,6 +329,7 @@ class Request(BaseRequest):
             'skip_preview': 'skipPreview',
             'ignore_errors': 'ignoreErrors',
             'grid': 'grid',
+            'extend': 'extend'
         }
 
         self.spatial_validations = [

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -472,6 +472,8 @@ def test_post_request_has_user_agent_headers(examples_dir):
     ({'width': 100}, 'width=100'),
     ({'concatenate': True}, 'concatenate=true'),
     ({'grid': 'theGridName'}, 'grid=theGridName'),
+    ({'extend': ['lat', 'lon']}, 'extend=lat&extend=lon'),
+    ({'extend': ['singleDimension']}, 'extend=singleDimension'),
 ])
 
 @responses.activate


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1568

## Description
Adds the extend param for passing a list of dimensions in the request.

## Local Test Steps
After activating your virtual environment, pip install -e . to get this branch version of harmony-py in your virtual environment.
Run through notebooks/examples/basic.ipynb. Modify the request to pass in `extend`. E.g.:

collection = Collection(id='C1234088182-EEDTEST')

request = Request(
    collection=collection,
    spatial=BBox(-165, 52, -140, 77),
    extend=['lat', 'lon']
)
Inspect the request URL after submitting the job: https://harmony.uat.earthdata.nasa.gov/workflow-ui -- you should see `&extend=...`.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)