### PR TITLE
Updated `basic.ipynb` in examples to use `username.placeholder` and `password.placeholder`

### DIFF
--- a/examples/basic.ipynb
+++ b/examples/basic.ipynb
@@ -86,7 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "harmony_client = Client(auth=(username.value, password.value), env=Environment.UAT)"
+    "harmony_client = Client(auth=(username.placeholder, password.placeholder), env=Environment.UAT)"
    ]
   },
   {


### PR DESCRIPTION
## Description
L68 and L70 use `placeholder` in `helper.Text` but when you try logging in (L89) it checks for value (`username.value` and `password.value`). I updated line L89 to check `username.placeholder` and `password.placeholder` instead.

## Local Test Steps
N/A No tests added

## PR Acceptance Checklist
* ~[ ] Acceptance criteria met~
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)