### PR TITLE
HARMONY-1721: Switch from using GET to a POST in all OGC coverages calls to harmony

### DIFF
--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -174,7 +174,8 @@ _valid_shapefile_exts = ', '.join((_shapefile_exts_to_mimes.keys()))
 
 
 class BaseRequest:
-    """A Harmony base request with the CMR collection. It is the base class of all harmony requests.
+    """A Harmony base request with the CMR collection. It is the base class of all harmony
+    requests.
 
     Args:
         collection: The CMR collection that should be queried
@@ -522,6 +523,11 @@ class Client:
                 self.session = create_session(self.config, auth=self.auth)
         return self.session
 
+    def _http_method(self, request: BaseRequest) -> str:
+        """Returns the HTTP method to use for the given request."""
+        method = 'GET' if isinstance(request, CapabilitiesRequest) else 'POST'
+        return method
+
     def _submit_url(self, request: BaseRequest) -> str:
         """Constructs the URL for the request that is used to submit a new Harmony Job."""
         if isinstance(request, CapabilitiesRequest):
@@ -731,10 +737,17 @@ class Client:
                                             headers=headers)
                 prepped_request = session.prepare_request(r)
             else:
-                r = requests.models.Request('GET',
-                                            self._submit_url(request),
-                                            params=params,
-                                            headers=headers)
+                method = self._http_method(request)
+                if method == 'POST':
+                    r = requests.models.Request('POST',
+                                                self._submit_url(request),
+                                                data=params,
+                                                headers=headers)
+                else:
+                    r = requests.models.Request('GET',
+                                                self._submit_url(request),
+                                                params=params,
+                                                headers=headers)
                 prepped_request = session.prepare_request(r)
 
         return prepped_request

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -742,7 +742,6 @@ class Client:
                                             files=all_files,
                                             headers=headers)
             else:
-                method = self._http_method(request)
                 r = requests.models.Request('GET',
                                             self._submit_url(request),
                                             params=params,

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -700,9 +700,9 @@ class Client:
                 concatenated_values = ','.join(map(str, values))
                 result.append((key, (None, concatenated_values, None)))
             else:
-              if not isinstance(values, list):
-                  values = [values]
-              result += [(key, (None, str(value), None)) for value in values]
+                if not isinstance(values, list):
+                    values = [values]
+                result += [(key, (None, str(value), None)) for value in values]
         return result
 
     def _get_prepared_request(self, request: BaseRequest) -> requests.models.PreparedRequest:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -522,7 +522,7 @@ def test_post_request_has_user_agent_headers(examples_dir):
     ({'crs': 'epsg:3141'}, 'outputcrs=epsg:3141'),
     ({'destination_url': 's3://bucket'}, 'destinationUrl=s3://bucket'),
     ({'format': 'r2d2/hologram'}, 'format=r2d2/hologram'),
-    ({'granule_id': ['G1', 'G2', 'G3']}, 'granuleId=G1&granuleId=G2&granuleId=G3'),
+    ({'granule_id': ['G1', 'G2', 'G3']}, 'granuleId=G1,G2,G3'),
     ({'granule_name': ['abc*123', 'ab?d123', 'abcd123']},
      'granuleName=abc*123&granuleName=ab?d123&granuleName=abcd123'),
     ({'height': 200}, 'height=200'),


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1721

## Description
harmony-py was using a GET for all calls to harmony, but this was causing 413 issues when trying to use a long list of granuleIds because of URL length limits. This PR switches to use a POST with multipart/form-data (we were already doing this when a shapefile was included in the request).

## Local Test Steps
Run `make test` and verify all tests pass.
Run the first request in the `examples/tutorial.ipynb` notebook. Note that there's a bug in harmony parsing width and height which will be addressed as a separate ticket. So you'll need to comment those out so the cell looks like this:
```
collection = Collection(id='C1234088182-EEDTEST')

request = Request(
    collection=collection,
    spatial=BBox(-165, 52, -140, 77),
    temporal={
        'start': dt.datetime(2010, 1, 1),
        'stop': dt.datetime(2020, 12, 30)
    },
    variables=['blue_var'],
    max_results=10,
    crs='EPSG:3995',
    format='image/tiff',
    # height=512,
    # width=512
)

request.is_valid()
```
Verify the request completes successfully. You can also check the harmony logs in the UAT environment to tell that it is using a POST and not a GET.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)