### PR TITLE
Harmony 1752

### DIFF
--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -24,7 +24,7 @@
     "import sys; sys.path.append('..')\n",
     "!{sys.executable} -m pip install -q -r ../requirements/examples.txt\n",
     "\n",
-    "# Install harmony-py requirements.  Not necessary if you ran `pip install harmony-py` in your kernel  \n",
+    "# Install harmony-py requirements.  Not necessary if you ran `pip install harmony-py` in your kernel\n",
     "!{sys.executable} -m pip install -q -r ../requirements/core.txt\n",
     "\n",
     "import datetime as dt\n",
@@ -176,10 +176,29 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f97fa92f",
+   "metadata": {},
+   "source": [
+    "We can also get a URL corresponding to our request that we can use in a browser. **Note:** This will not work if the request includes a shapefile."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f03e22a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = harmony_client.request_as_url(request)\n",
+    "print(url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "45a14473",
    "metadata": {},
    "source": [
-    "Let's build another request. This time, we'll request a specific granule and grid using the UMM grid name from the CMR. You can find grids in the CMR at https://cmr.uat.earthdata.nasa.gov/search/grids.umm_json. Include a query parameter `?name=LambertExample` to list detailed information about a specific grid."
+    "Let's build another request. This time, we'll request a specific granule and grid using the UMM grid name from the CMR. You can find grids in the CMR at https://cmr.uat.earthdata.nasa.gov/search/grids.umm_json. Include a query parameter `?grid=LambertExample` to list detailed information about a specific grid."
    ]
   },
   {
@@ -317,7 +336,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.11.9"
   },
   "vscode": {
    "interpreter": {

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -706,11 +706,12 @@ class Client:
                 result += [(key, (None, str(value), None)) for value in values]
         return result
 
-    def _get_prepared_request(self, request: BaseRequest) -> requests.models.PreparedRequest:
+    def _get_prepared_request(self, request: BaseRequest, for_browser=False) -> requests.models.PreparedRequest:
         """Returns a :requests.models.PreparedRequest: object for the given harmony Request
 
         Args:
             request: The Harmony Request to prepare
+            for_browser: if True only the url with query params will be returned
 
         Returns:
             A PreparedRequest
@@ -722,7 +723,7 @@ class Client:
 
         method = self._http_method(request)
         with self._files(request) as files:
-            if files or method == 'POST':
+            if (files or method == 'POST') and not for_browser:
                 # Ideally this should just be files=files, params=params but Harmony
                 # cannot accept both files and query params now.  (HARMONY-290)
                 # Inflate params to a list of tuples that can be passed as multipart
@@ -742,11 +743,17 @@ class Client:
                                             files=all_files,
                                             headers=headers)
             else:
+                if files:
+                    raise Exception(f"Cannot include shapefile as URL query parameter")
+
                 r = requests.models.Request('GET',
                                             self._submit_url(request),
                                             params=params,
                                             headers=headers)
+
             prepped_request = session.prepare_request(r)
+            if for_browser:
+                prepped_request.headers = None
 
         return prepped_request
 
@@ -797,6 +804,21 @@ class Client:
             cooks['token'] = '*****'
             prepped_request.prepare_cookies(cooks)
         return curlify.to_curl(prepped_request)
+
+    def request_as_url(self, request: BaseRequest) -> str:
+        """Returns a URL string representation of the given request.
+        **Note** Headers and cookies are not included, just the URL.
+        Shapefiles are not supported.
+
+        Args:
+            request: The Request to build the URL string for
+
+        Returns:
+            A URL string that can be pasted into a browser.
+        :raises
+            Exception: if a shapefile is included in the request.
+        """
+        return self._get_prepared_request(request, for_browser=True).url
 
     def submit(self, request: BaseRequest) -> any:
         """Submits a request to Harmony and returns the Harmony Job ID.

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -706,7 +706,8 @@ class Client:
                 result += [(key, (None, str(value), None)) for value in values]
         return result
 
-    def _get_prepared_request(self, request: BaseRequest, for_browser=False) -> requests.models.PreparedRequest:
+    def _get_prepared_request(
+            self, request: BaseRequest, for_browser=False) -> requests.models.PreparedRequest:
         """Returns a :requests.models.PreparedRequest: object for the given harmony Request
 
         Args:
@@ -744,7 +745,7 @@ class Client:
                                             headers=headers)
             else:
                 if files:
-                    raise Exception(f"Cannot include shapefile as URL query parameter")
+                    raise Exception("Cannot include shapefile as URL query parameter")
 
                 r = requests.models.Request('GET',
                                             self._submit_url(request),
@@ -759,7 +760,7 @@ class Client:
 
     def _handle_error_response(self, response: Response):
         """Raises the appropriate exception based on the response
-        received from Harmony. Trys to pull out an error message
+        received from Harmony. Tries to pull out an error message
         from a Harmony JSON response when possible.
 
         Args:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1502,6 +1502,28 @@ def test_request_as_curl_post(examples_dir):
            f'/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset' in curl_command
     assert '-X POST' in curl_command
 
+def test_request_as_url():
+    collection = Collection(id='C1940468263-POCLOUD')
+    request = Request(
+        collection=collection,
+        spatial=BBox(-107, 40, -105, 42)
+    )
+
+    url = Client(should_validate_auth=False).request_as_url(request)
+    assert url == 'https://harmony.earthdata.nasa.gov/C1940468263-POCLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=true&subset=lat%2840%3A42%29&subset=lon%28-107%3A-105%29'
+
+def test_request_with_shapefile_as_url(examples_dir):
+    collection = Collection(id='C1940468263-POCLOUD')
+    request = Request(
+        collection=collection,
+        shape=os.path.join(examples_dir, 'asf_example.json'),
+        spatial=BBox(-107, 40, -105, 42)
+    )
+
+    with pytest.raises(Exception) as e:
+        Client(should_validate_auth=False).request_as_url(request)
+    assert str(e.value) == "Cannot include shapefile as URL query parameter"
+
 @responses.activate
 def test_collection_capabilities():
     collection_id='C1940468263-POCLOUD'


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1752

## Description
Adds a new method to the `Client` class, `request_as_url` that returns a URL string that can be pasted into a browser.

## Local Test Steps
Run the tutorial.ipynb notebook. The ninth code cell will output a URL string. Paste this into a browser and verify that it runs a Harmony job.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)