### PR TITLE
HARMONY-1793: Fixed warning message in readthedocs for shapely module.

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -5,3 +5,4 @@ nbconvert ~= 7.10.0
 progressbar2 ~= 4.2.0
 sphinx ~= 7.1.2
 sphinx-rtd-theme ~= 1.3.0
+shapely ~= 2.0.4


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1793

## Description
This fixes the warning message in readthedocs for shapely module.

## Local Test Steps
The warning message about `No module named 'shapely'` in readthedocs build is gone.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)