### PR TITLE
Harmony 1838 - Clarify supported python versions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: '0'
     - uses: actions/setup-python@v4

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: '0'
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
     - shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,5 +28,6 @@ jobs:
     - name: Archive code coverage results
       uses: actions/upload-artifact@v4
       with:
-        name: code-coverage-report
+        name: code-coverage-report ${{ github.event.pull_request.head.sha }}
         path: htmlcov/*
+      if: ${{ github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
         python-version: [3.8, 3.9, '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
@@ -26,7 +26,7 @@ jobs:
         make ci
 
     - name: Archive code coverage results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: code-coverage-report
         path: htmlcov/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,6 @@ jobs:
     - name: Archive code coverage results
       uses: actions/upload-artifact@v4
       with:
-        name: code-coverage-report ${{ github.event.pull_request.head.sha }}
+        name: code-coverage-report ${{ github.event.pull_request.head.sha }} ${{ matrix.python-version }}
         path: htmlcov/*
       if: ${{ github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize') }}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We welcome feedback on Harmony-Py via [GitHub Issues](https://github.com/nasa/ha
 
 ## Prerequisites
 
-* Python 3.8+
+* Python 3.8 through 3.11 (other versions are end of life or untested)
 
 
 ## Installing
@@ -28,7 +28,7 @@ This will install harmony-py and its dependencies into your current Python envir
 
 ## Prerequisites
 
-* Python 3.7+, ideally installed via a virtual environment
+* Python 3.8 through 3.11, ideally installed via a virtual environment
 
 
 ## Installing Development & Example Dependencies

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,6 @@ setup(
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
@@ -58,7 +56,7 @@ setup(
     ],
     keywords='nasa, harmony, remote-sensing, science, geoscience',
     packages=find_packages(exclude=['tests']),
-    python_requires='>=3.6, <4',
+    python_requires='>=3.8, <4',
     install_requires=DEPENDENCIES,
     extras_require={
         'dev': DEV_DEPENDENCIES,


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1838

## Description
1. Clarifies supported python versions (to address https://github.com/nasa/harmony-py/issues/78)

2. Updates some deprecated GitHub actions. 

3. Modifies the "Tests" GitHub workflow so that detailed HTML code coverage reports are only uploaded to GitHub on pull request open or synchronize events. (For every commit, the tests will still run and the code coverage summary will still be printed to the GitHub actions web UI). If developers want the full HTML coverage report outside of pull requests, it can be generated locally, on demand via `make test`.

## Local Test Steps
run `make ci`

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)