### PR TITLE
HARMONY-1859: Add WKT POINT support in harmony-py.

### DIFF
--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -340,6 +340,7 @@
     "request = Request(\n",
     "    collection=collection,\n",
     "    spatial=WKT('POLYGON((-140 20, -50 20, -50 60, -140 60, -140 20))'),\n",
+    "    # spatial=WKT('POINT(-40 10)'),\n",
     "    granule_id=['C1233800302-EEDTEST'],\n",
     "    max_results=1,\n",
     "    temporal={\n",
@@ -384,6 +385,14 @@
     "    if filename.endswith(\"png\"):\n",
     "        helper.show_result(filename)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09f132f3-6117-4ca0-b2b6-ae41c6b48981",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -325,7 +325,7 @@
    "id": "a22a34f6-36a5-4554-b248-1b3e599dc4c2",
    "metadata": {},
    "source": [
-    "Example of submitting a request with WKT spatial:"
+    "Example of submitting a request with WKT spatial. The supported WKT geometry types are listed at: https://harmony-py.readthedocs.io/en/latest/api.html#harmony.harmony.WKT"
    ]
   },
   {
@@ -340,7 +340,6 @@
     "request = Request(\n",
     "    collection=collection,\n",
     "    spatial=WKT('POLYGON((-140 20, -50 20, -50 60, -140 60, -140 20))'),\n",
-    "    # spatial=WKT('POINT(-40 10)'),\n",
     "    granule_id=['C1233800302-EEDTEST'],\n",
     "    max_results=1,\n",
     "    temporal={\n",

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -607,6 +607,20 @@ class Client:
         method = 'GET' if isinstance(request, CapabilitiesRequest) else 'POST'
         return method
 
+    def _wkt_to_edr_route(self, wkt_string: str) -> str:
+        """Returns the EDR route for the given WKT string."""
+        # Load the WKT string into a Shapely geometry object
+        geometry = loads(wkt_string)
+
+        if geometry.geom_type == 'Polygon' or geometry.geom_type == 'MultiPolygon':
+            return 'area'
+        elif geometry.geom_type == 'Point' or geometry.geom_type == 'MultiPoint':
+            return 'position'
+        elif geometry.geom_type == 'LineString' or geometry.geom_type == 'MultiLineString':
+            return 'trajectory'
+        else:
+            raise Exception(f"Unsupported geometry type: {geometry.geom_type}")
+
     def _submit_url(self, request: BaseRequest) -> str:
         """Constructs the URL for the request that is used to submit a new Harmony Job."""
         if isinstance(request, CapabilitiesRequest):
@@ -616,7 +630,7 @@ class Client:
                 f'{self.config.root_url}'
                 f'/ogc-api-edr/1.1.0/collections'
                 f'/{request.collection.id}'
-                f'/area'
+                f'/{self._wkt_to_edr_route(request.spatial.wkt)}'
             )
         else:
             return (

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -151,7 +151,15 @@ class BBox(NamedTuple):
 
 
 class WKT:
-    """The Well Known Text (WKT) representation of Spatial."""
+    """The Well Known Text (WKT) representation of Spatial.
+    Supported WKT geometry types are: POINT, MULTIPOINT, POLYGON, MULTIPOLYGON.
+
+    Example:
+        spatial=WKT('POINT(-40 10)')
+        spatial=WKT('MULTIPOINT((-77 38.9),(-40 10))')
+        spatial=WKT('POLYGON((-140 20, -50 20, -50 60, -140 60, -140 20))')
+        spatial=WKT('MULTIPOLYGON(((10 10, 20 20, 30 10, 10 10)),((40 40, 50 50, 60 40, 40 40)))')
+    """
 
     def __init__(self, wkt: str):
         """Constructs a WKT instance of spatial area.
@@ -256,7 +264,8 @@ class Request(BaseRequest):
     Args:
         collection: The CMR collection that should be queried
 
-        spatial: Bounding box spatial constraints on the data
+        spatial: Bounding box spatial constraints on the data or Well Known Text (WKT) string
+          describing the spatial constraints.
 
         temporal: Date/time constraints on the data provided as a dict mapping "start" and "stop"
           keys to corresponding start/stop datetime.datetime objects

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -156,8 +156,11 @@ class WKT:
 
     Example:
         spatial=WKT('POINT(-40 10)')
+
         spatial=WKT('MULTIPOINT((-77 38.9),(-40 10))')
+
         spatial=WKT('POLYGON((-140 20, -50 20, -50 60, -140 60, -140 20))')
+
         spatial=WKT('MULTIPOLYGON(((10 10, 20 20, 30 10, 10 10)),((40 40, 50 50, 60 40, 40 40)))')
     """
 


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1859

## Description
Add WKT POINT support in harmony-py.

## Local Test Steps
make examples
Then run tutorial notebook, modify the spatial parameter for the last test to use POINT or MULTIPOINT, e.g. 
`spatial=WKT('POINT(-40 10)'),`
or 
`spatial=WKT('MULTIPOINT((-77 38.9),(-40 10))'),`
Verify the harmony-py request is submitted as EDR position request in harmony and runs successfully.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)