### PR TITLE
Harmony 1929 - Ensure OPeNDAP downloads use POST

### DIFF
--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -1243,6 +1243,8 @@ class Client:
         Returns:
             A boolean indicating whether the data is staged data.
         """
+        if 'harmony' not in url:
+            return False
         url_parts = url.split('/')
         possible_uuid = url_parts[-3]
         possible_item_id = url_parts[-2]
@@ -1266,10 +1268,11 @@ class Client:
         Returns:
             The filename that will be used to name the downloaded file.
         """
-        url_parts = url.split('/')
+        url_no_query = parse.urlunparse(parse.urlparse(url)._replace(query=""))
+        url_parts = url_no_query.split('/')
         original_filename = url_parts[-1]
 
-        is_staged_result = self._is_staged_result(url)
+        is_staged_result = self._is_staged_result(url_no_query)
         if not is_staged_result:
             return original_filename
         item_id = url_parts[-2]

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -1317,13 +1317,14 @@ class Client:
             parse_result = parse.urlparse(url)
             is_opendap = parse_result.netloc.startswith('opendap')
             method = 'post' if is_opendap else 'get'
-            if is_opendap: # remove the query params from the URL and convert to dict
+            if is_opendap:  # remove the query params from the URL and convert to dict
                 new_url = parse.urlunparse(parse_result._replace(query=""))
                 data_dict = dict(parse.parse_qsl(parse.urlsplit(url).query))
             headers = {
                 "Accept-Encoding": "identity"
             }
-            with getattr(session, method)(new_url, data=data_dict, stream=True, headers=headers) as r:
+            with getattr(session, method)(
+                    new_url, data=data_dict, stream=True, headers=headers) as r:
                 with open(filename, 'wb') as f:
                     shutil.copyfileobj(r.raw, f, length=chunksize)
             if verbose and verbose.upper() == 'TRUE':

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -1309,7 +1309,7 @@ class Client:
                 print(filename)
             return filename
         else:
-            data_dict = {}
+            data_dict = None
             parse_result = parse.urlparse(url)
             is_opendap = parse_result.netloc.startswith('opendap')
             method = 'post' if is_opendap else 'get'

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -1302,6 +1302,7 @@ class Client:
         chunksize = int(self.config.DOWNLOAD_CHUNK_SIZE)
         session = self._session()
         filename = self.get_download_filename_from_url(url)
+        new_url = url
 
         if directory:
             filename = os.path.join(directory, filename)
@@ -1317,12 +1318,12 @@ class Client:
             is_opendap = parse_result.netloc.startswith('opendap')
             method = 'post' if is_opendap else 'get'
             if is_opendap: # remove the query params from the URL and convert to dict
-                url = parse.urlunparse(parse_result._replace(query=""))
+                new_url = parse.urlunparse(parse_result._replace(query=""))
                 data_dict = dict(parse.parse_qsl(parse.urlsplit(url).query))
             headers = {
                 "Accept-Encoding": "identity"
             }
-            with getattr(session, method)(url, data=data_dict, stream=True, headers=headers) as r:
+            with getattr(session, method)(new_url, data=data_dict, stream=True, headers=headers) as r:
                 with open(filename, 'wb') as f:
                     shutil.copyfileobj(r.raw, f, length=chunksize)
             if verbose and verbose.upper() == 'TRUE':

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1019,16 +1019,16 @@ def test_download_opendap_file():
         file_obj.write(expected_data)
         file_obj.seek(0)
         with responses.RequestsMock() as resp_mock:
-            resp_mock.add(responses.POST, path + expected_filename, body=file_obj.read(), stream=True)
+            resp_mock.add(responses.POST, path + expected_filename, body=file_obj.read(), stream=True,
+                match=[responses.matchers.urlencoded_params_matcher({"dap4.ce": "/ds_surf_type[0:1:4]"})])
             client = Client(should_validate_auth=False)
             actual_output = client._download_file(url, overwrite=False)
-    
-    # TODO assert POST body params are as expected
     
     assert actual_output == expected_filename
     with open(expected_filename, 'rb') as temp_file:
         data = temp_file.read()
         assert data == expected_data
+
     os.unlink(actual_output)
 
 def test_download_all(mocker):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1007,6 +1007,29 @@ def test_download_file(overwrite):
     if not overwrite:
         os.unlink(expected_filename)
 
+def test_download_opendap_file():
+    expected_data = bytes('abcde', encoding='utf-8')
+    expected_filename = 'SC:ATL03.006:264549068'
+    query = '?dap4.ce=/ds_surf_type[0:1:4]'
+    path = 'https://opendap.uat.earthdata.nasa.gov/collections/C1261703111-EEDTEST/granules/'
+    url = path + expected_filename + query
+    actual_output = None
+
+    with io.BytesIO() as file_obj:
+        file_obj.write(expected_data)
+        file_obj.seek(0)
+        with responses.RequestsMock() as resp_mock:
+            resp_mock.add(responses.POST, path + expected_filename, body=file_obj.read(), stream=True)
+            client = Client(should_validate_auth=False)
+            actual_output = client._download_file(url, overwrite=False)
+    
+    # TODO assert POST body params are as expected
+    
+    assert actual_output == expected_filename
+    with open(expected_filename, 'rb') as temp_file:
+        data = temp_file.read()
+        assert data == expected_data
+    os.unlink(actual_output)
 
 def test_download_all(mocker):
     expected_urls = [


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1929

## Description
Since opendap can have potentially very long data download URLs we need to ensure that we convert the query string to POST body parameters in those cases and submit a POST request.

**_NOTE:_** I did see OPeNDAP timing out for very long URLs.

The snyk check is failing due to an internal snyk error.

## Local Test Steps
This is how I tested:

1. With a local harmony instance running, submit a request.
2. Once it finishes, change one of the job link data URLs in the job links table to:
https://opendap.uat.earthdata.nasa.gov/collections/C1261703111-EEDTEST/granules/SC:ATL03.006:264549068.dap.nc4?dap4.ce=/ds_surf_type[0:1:4]
3. Copy the job ID for this job as you will use it to make a download request with harmony-py.
4. Create a virtual environment with this version of harmony-py installed (`pip install -e ./path/to/harmony_py`). 
5. In a notebook (see basic.ipynb), create a client with `env=Environment.LOCAL` and make a download request (e.g. `harmony_client.download_all('88aebf3b-bb47-475d-8d54-05fa9812ae77', overwrite=True)`).
6. Verify that the opendap data is successfully retrieved.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)