### PR TITLE
Harmony 1929-2: Remove colon from downloaded file name

### DIFF
--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -1276,7 +1276,7 @@ class Client:
         is_staged_result = self._is_staged_result(url_no_query)
         if not is_staged_result:
             name_result = original_filename
-        else:    
+        else:
             item_id = url_parts[-2]
             name_result = f'{item_id}_{original_filename}'
         return name_result.replace(':', '_')

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -1268,15 +1268,18 @@ class Client:
         Returns:
             The filename that will be used to name the downloaded file.
         """
+        name_result = None
         url_no_query = parse.urlunparse(parse.urlparse(url)._replace(query=""))
         url_parts = url_no_query.split('/')
         original_filename = url_parts[-1]
 
         is_staged_result = self._is_staged_result(url_no_query)
         if not is_staged_result:
-            return original_filename
-        item_id = url_parts[-2]
-        return f'{item_id}_{original_filename}'
+            name_result = original_filename
+        else:    
+            item_id = url_parts[-2]
+            name_result = f'{item_id}_{original_filename}'
+        return name_result.replace(':', '_')
 
     def _download_file(self, url: str, directory: str = '', overwrite: bool = False) -> str:
         """Downloads data, saves it to a file, and returns the filename.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1009,17 +1009,18 @@ def test_download_file(overwrite):
 
 def test_download_opendap_file():
     expected_data = bytes('abcde', encoding='utf-8')
-    expected_filename = 'SC:ATL03.006:264549068'
+    filename = 'SC:ATL03.006:264549068'
+    expected_filename = 'SC_ATL03.006_264549068'
     query = '?dap4.ce=/ds_surf_type[0:1:4]'
     path = 'https://opendap.uat.earthdata.nasa.gov/collections/C1261703111-EEDTEST/granules/'
-    url = path + expected_filename + query
+    url = path + filename + query
     actual_output = None
 
     with io.BytesIO() as file_obj:
         file_obj.write(expected_data)
         file_obj.seek(0)
         with responses.RequestsMock() as resp_mock:
-            resp_mock.add(responses.POST, path + expected_filename, body=file_obj.read(), stream=True,
+            resp_mock.add(responses.POST, path + filename, body=file_obj.read(), stream=True,
                 match=[responses.matchers.urlencoded_params_matcher({"dap4.ce": "/ds_surf_type[0:1:4]"})])
             client = Client(should_validate_auth=False)
             actual_output = client._download_file(url, overwrite=False)


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1929

## Description
A follow up/revision to https://github.com/nasa/harmony-py/pull/97 (removes colons from downloaded file name).

## Local Test Steps
`make test`

or for an end-to-end test see https://github.com/nasa/harmony-py/pull/97

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)