### PR TITLE
Harmony 1936: Add default job label to harmony-py jobs

### DIFF
--- a/examples/basic.ipynb
+++ b/examples/basic.ipynb
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "impaired-transfer",
    "metadata": {},
    "outputs": [],
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "peripheral-cattle",
    "metadata": {},
    "outputs": [],
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "charming-wheat",
    "metadata": {},
    "outputs": [],
@@ -107,12 +107,14 @@
    "id": "tracked-distributor",
    "metadata": {},
    "source": [
-    "Now that we have a request, we can submit it to Harmony using the Harmony Client object we created earlier. We'll get back a job id belonging to our Harmony request."
+    "Now that we have a request, we can submit it to Harmony using the Harmony Client object we created earlier. We'll get back a job id belonging to our Harmony request.\n",
+    "\n",
+    "By default the job will have a 'harmony_py' label. This can be disabled by setting the `EXCLUDE_DEFAULT_LABEL` environment variable to \"true\" before making the request."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "entertaining-romania",
    "metadata": {},
    "outputs": [],

--- a/examples/basic.ipynb
+++ b/examples/basic.ipynb
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "impaired-transfer",
    "metadata": {},
    "outputs": [],
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "peripheral-cattle",
    "metadata": {},
    "outputs": [],
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "charming-wheat",
    "metadata": {},
    "outputs": [],
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "entertaining-romania",
    "metadata": {},
    "outputs": [],

--- a/examples/intro_tutorial.ipynb
+++ b/examples/intro_tutorial.ipynb
@@ -259,7 +259,9 @@
    "source": [
     "### Submit Request\n",
     "\n",
-    "Once you have created your request, you can now submit it to Harmony using the Harmony Client object. A job id is returned, which is a unique identifier that represents your submitted request. "
+    "Once you have created your request, you can now submit it to Harmony using the Harmony Client object. A job id is returned, which is a unique identifier that represents your submitted request.\n",
+    "\n",
+    "By default the job will have a 'harmony_py' label. This can be disabled by setting the `EXCLUDE_DEFAULT_LABEL` environment variable to \"true\" before making the request."
    ]
   },
   {
@@ -625,7 +627,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "harmony-py-notebooks",
    "language": "python",
    "name": "python3"
   },
@@ -639,12 +641,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "d0b323d74a2eccdefaacaf33c041ca03218ebb6c9aa84851ec587afd8a56d428"
-   }
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -48,7 +48,7 @@ from harmony.auth import create_session, validate_auth
 from harmony.config import Config, Environment
 from harmony import __version__ as harmony_version
 
-DEFAULT_JOB_LABEL = "harmony_py"
+DEFAULT_JOB_LABEL = "harmony-py"
 
 progressbar_widgets = [
     ' [ Processing: ', progressbar.Percentage(), ' ] ',

--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -48,6 +48,8 @@ from harmony.auth import create_session, validate_auth
 from harmony.config import Config, Environment
 from harmony import __version__ as harmony_version
 
+DEFAULT_JOB_LABEL = "harmony_py"
+
 progressbar_widgets = [
     ' [ Processing: ', progressbar.Percentage(), ' ] ',
     progressbar.Bar(),
@@ -352,7 +354,8 @@ class Request(BaseRequest):
                  concatenate: bool = None,
                  skip_preview: bool = None,
                  ignore_errors: bool = None,
-                 grid: str = None):
+                 grid: str = None,
+                 labels: List[str] = None):
         """Creates a new Request instance from all specified criteria.'
         """
         super().__init__(collection=collection)
@@ -377,6 +380,7 @@ class Request(BaseRequest):
         self.skip_preview = skip_preview
         self.ignore_errors = ignore_errors
         self.grid = grid
+        self.labels = labels
 
         if self.is_edr_request():
             self.variable_name_to_query_param = {
@@ -397,7 +401,8 @@ class Request(BaseRequest):
                 'ignore_errors': 'ignoreErrors',
                 'grid': 'grid',
                 'extend': 'extend',
-                'variables': 'parameter-name'
+                'variables': 'parameter-name',
+                'labels': 'label',
             }
             self.spatial_validations = [
                 (lambda s: is_wkt_valid(s.wkt), f'WKT {spatial.wkt} is invalid'),
@@ -421,7 +426,8 @@ class Request(BaseRequest):
                 'ignore_errors': 'ignoreErrors',
                 'grid': 'grid',
                 'extend': 'extend',
-                'variables': 'variable'
+                'variables': 'variable',
+                'labels': 'label',
             }
 
             self.spatial_validations = [
@@ -694,6 +700,10 @@ class Client:
 
                 if len(subset) > 0:
                     params['subset'] = subset
+            if (os.getenv('EXCLUDE_DEFAULT_LABEL') != 'true'):
+                labels = getattr(params, 'labels', [])
+                labels.append(DEFAULT_JOB_LABEL)
+                params['label'] = labels
 
         skipped_params = ['shapefile']
         query_params = [pv for pv in request.parameter_values() if pv[0] not in skipped_params]
@@ -1235,7 +1245,7 @@ class Client:
 
     def _is_staged_result(self, url: str) -> str:
         """Check if the URL indicates that the data is associated with actual
-        service ouputs (as opposed to a download link for example).
+        service outputs (as opposed to a download link for example).
 
         Args:
             url: The location (URL) of the file to be downloaded


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1936

## Description
This PR adds a default label of 'harmony-py' to jobs created with this library. It can be disabled by setting the environment variable `EXCLUDE_DEFAULT_LABEL` to "true".

## Local Test Steps
1. Run the example/basic.ipynb notebook.
2. Verify that the created job has a 'harmony-py' label
3. set the `EXCLUDE_DEFAULT_LABEL` env var to "true"
4. Run the example notebook again.
5. Verify that the created job has no label.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)