### PR TITLE
HARMONY-1993: Allow users to set custom labels for harmony requests.

### DIFF
--- a/harmony/harmony.py
+++ b/harmony/harmony.py
@@ -327,6 +327,10 @@ class Request(BaseRequest):
         grid: The name of the output grid to use for regridding requests. The name must
           match the UMM grid name in the CMR.
 
+        labels: The list of labels to include for the request. By default a 'harmony-py'
+          label is added to all requests unless the environment variable EXCLUDE_DEFAULT_LABEL
+          is set to 'true'.
+
     Returns:
         A Harmony Transformation Request instance
     """
@@ -681,6 +685,7 @@ class Client:
     def _params(self, request: BaseRequest) -> dict:
         """Creates a dictionary of request query parameters from the given request."""
         params = {}
+        skipped_params = ['shapefile']
         if not isinstance(request, CapabilitiesRequest):
             if request.is_edr_request():
                 params['forceAsync'] = True
@@ -701,11 +706,11 @@ class Client:
                 if len(subset) > 0:
                     params['subset'] = subset
             if (os.getenv('EXCLUDE_DEFAULT_LABEL') != 'true'):
-                labels = getattr(params, 'labels', [])
+                labels = request.labels or []
                 labels.append(DEFAULT_JOB_LABEL)
                 params['label'] = labels
+                skipped_params.append('label')
 
-        skipped_params = ['shapefile']
         query_params = [pv for pv in request.parameter_values() if pv[0] not in skipped_params]
         for p, val in query_params:
             if isinstance(val, str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "python-dateutil ~= 2.8.2",
+    "python-dateutil ~= 2.9",
     "python-dotenv ~= 0.20.0",
     "progressbar2 ~= 4.2.0",
     "requests ~= 2.32.3",
@@ -45,15 +45,15 @@ Repository = "https://github.com/nasa/harmony-py.git"
 
 [project.optional-dependencies]
 dev = [
-    "coverage ~= 5.4",
+    "coverage ~= 7.4",
     "flake8 ~= 7.1.1",
-    "hypothesis ~= 6.2",
+    "hypothesis ~= 6.103",
     "PyYAML ~= 6.0.1",
-    "pytest ~= 6.2",
-    "pytest-cov ~= 2.11",
-    "pytest-mock ~= 3.5",
+    "pytest ~= 8.2",
+    "pytest-cov ~= 5.0",
+    "pytest-mock ~= 3.14",
     "pytest-watch ~= 4.2",
-    "responses ~= 0.25.3"
+    "responses ~= 0.25.6"
 ]
 docs = [
     "curlify ~= 2.2.1",


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1993

## Description
Allows users to set custom labels on harmony requests.

Note that I also upgraded some libraries to eliminate several warnings.

## Local Test Steps
Bring up one of the notebooks like `tutorial.ipynb`. Modify a request to set labels by adding `labels=['foo', 'bar']` to the request constructor. Verify that the harmony request that gets created includes the labels 'foo', 'bar', and 'harmony-py'.

Repeat the test after setting the environment variable `EXCLUDE_DEFAULT_LABEL=true`. Verify that the labels 'foo' and 'bar' are included in the request, but not 'harmony-py'.

Verify that submitting a request without any labels field also works.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [X] Documentation updated (if needed)