### PR TITLE
HARMONY-1997: As a harmony-py user I would like to see a warning message when a job results in no data.

### DIFF
--- a/harmony/client.py
+++ b/harmony/client.py
@@ -958,23 +958,20 @@ class Client:
             result.
         """
         if isinstance(job_id_or_result_json, str):
-            num_files = 0
             try:
+                num_files = 0
                 for url in self.result_urls(job_id_or_result_json, show_progress=False) or []:
                     num_files += 1
                     if url.endswith('zarr'):
                         raise self.zarr_download_exception
                     yield self.executor.submit(self._download_file, url, directory, overwrite)
+
+                if num_files == 0:
+                    print('\nThere is no file to download.', file=sys.stderr)
+                    status, message = self.job_status_message(job_id_or_result_json)
+                    print(f'\nJob status is {status} with message: {message}.', file=sys.stderr)
             except ProcessingFailedException:
                 print('\nJob Status is failed. There is no file to download.', file=sys.stderr)
-                # set num_files to 1 to bypass the extra error reporting below
-                # as it has already been reported
-                num_files = 1
-
-            if num_files == 0:
-                print('\nThere is no file to download.', file=sys.stderr)
-                status, message = self.job_status_message(job_id_or_result_json)
-                print(f'\nJob status is {status} with message: {message}.', file=sys.stderr)
         else:
             for link in job_id_or_result_json.get('links', []):
                 if link['rel'] == 'data':

--- a/harmony/client.py
+++ b/harmony/client.py
@@ -967,7 +967,8 @@ class Client:
                     yield self.executor.submit(self._download_file, url, directory, overwrite)
             except ProcessingFailedException:
                 print('\nJob Status is failed. There is no file to download.', file=sys.stderr)
-                # set num_files to 1 to bypass the extra error reporting below as it has already been reported
+                # set num_files to 1 to bypass the extra error reporting below
+                # as it has already been reported
                 num_files = 1
 
             if num_files == 0:


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1997

## Description
Updated harmony-py to report error when there is no files to download for failed or warning requests during `client.download_all` invocation.

## Local Test Steps
Since we have to use customized (fake) service image to get requests into warning state, it doesn't make sense to add a notebook to demonstrate this behavior. Also the current failed request notebook is returning success probably due to recent configuration changes which we will have to fix as a separate issue (HARMONY-2034).

Here is a notebook snippet to test the error reporting for warning request. I will restore the faked service-example image in UAT once this PR is merged.  

```
import helper
helper.install_project_and_dependencies('..', libs=['examples'])
import json
import sys
import datetime as dt
from harmony import BBox, Client, Collection, Request, Environment

harmony_client = Client(env=Environment.UAT)

collection = Collection(id='C1233800302-EEDTEST')

request = Request(
    collection=collection,
    spatial=BBox(-140, 20, -50, 60),
    granule_id='G1233800343-EEDTEST',
    crs='EPSG:31975',
    variables=['blue_var'],
    format='image/png'
)

job_id = harmony_client.submit(request)

for filename in [f.result() for f in harmony_client.download_all(job_id)]:
    print(f'\nDownload file: {filename}')
```

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)