### PR TITLE
HARMONY-2035: As a harmony-py user, I want to request pixel subsetting.

### DIFF
--- a/harmony/client.py
+++ b/harmony/client.py
@@ -262,17 +262,6 @@ class Client:
 
         return params
 
-    def _params_to_json(self, params: Mapping[str, Any]) -> Mapping[str, Any]:
-        """Returns the given parameter mapping as a JSON POST body
-        Args:
-            params: A dictionary of parameter mappings as returned by self._params(request)
-
-        Returns:
-            A JSON map that can be submitted as a POST body
-        """
-        return {key: (value == 'true' if key in boolean_params else value)
-                for key, value in params.items()}
-
     def _headers(self) -> dict:
         """
         Create (if needed) and return a dictionary of headers.
@@ -427,7 +416,7 @@ class Client:
                 if request.is_edr_request():
                     r = requests.models.Request('POST',
                                                 self._submit_url(request),
-                                                json=self._params_to_json(params),
+                                                json=params,
                                                 headers=headers)
                 else:
                     param_items = self._params_dict_to_files(params)

--- a/harmony/request.py
+++ b/harmony/request.py
@@ -426,7 +426,15 @@ class Request(OgcBaseRequest):
         ]
         self.parameter_validations = [  # for simple, one-off validations
             (True if self.destination_url is None else self.destination_url.startswith('s3://'),
-             ('Destination URL must be an S3 location'))
+             'Destination URL must be an S3 location'),
+            (self.concatenate is None or isinstance(self.concatenate, bool),
+             'concatenate must be either True of False'),
+            (self.ignore_errors is None or isinstance(self.ignore_errors, bool),
+             'ignore_errors must be either True of False'),
+            (self.skip_preview is None or isinstance(self.skip_preview, bool),
+             'skip_preview must be either True of False'),
+            (self.pixel_subset is None or isinstance(self.pixel_subset, bool),
+             'pixel_subset must be either True of False')
         ]
 
     def _shape_error_messages(self, shape) -> List[str]:

--- a/harmony/request.py
+++ b/harmony/request.py
@@ -285,6 +285,8 @@ class Request(OgcBaseRequest):
           label is added to all requests unless the environment variable EXCLUDE_DEFAULT_LABEL
           is set to 'true'.
 
+        pixel_subset: Whether to perform pixel subset
+
     Returns:
         A Harmony Transformation Request instance
     """
@@ -313,7 +315,8 @@ class Request(OgcBaseRequest):
                  skip_preview: bool = None,
                  ignore_errors: bool = None,
                  grid: str = None,
-                 labels: List[str] = None):
+                 labels: List[str] = None,
+                 pixel_subset: bool = None):
         """Creates a new Request instance from all specified criteria.'
         """
         super().__init__(collection=collection)
@@ -339,6 +342,7 @@ class Request(OgcBaseRequest):
         self.ignore_errors = ignore_errors
         self.grid = grid
         self.labels = labels
+        self.pixel_subset = pixel_subset
 
         if self.is_edr_request():
             self.variable_name_to_query_param = {
@@ -361,6 +365,7 @@ class Request(OgcBaseRequest):
                 'extend': 'extend',
                 'variables': 'parameter-name',
                 'labels': 'label',
+                'pixel_subset': 'pixelSubset',
             }
             self.spatial_validations = [
                 (lambda s: is_wkt_valid(s.wkt), f'WKT {spatial.wkt} is invalid'),
@@ -386,6 +391,7 @@ class Request(OgcBaseRequest):
                 'extend': 'extend',
                 'variables': 'variable',
                 'labels': 'label',
+                'pixel_subset': 'pixelSubset',
             }
 
             self.spatial_validations = [

--- a/harmony/request.py
+++ b/harmony/request.py
@@ -428,13 +428,13 @@ class Request(OgcBaseRequest):
             (True if self.destination_url is None else self.destination_url.startswith('s3://'),
              'Destination URL must be an S3 location'),
             (self.concatenate is None or isinstance(self.concatenate, bool),
-             'concatenate must be either True of False'),
+             'concatenate must be a boolean (True or False)'),
             (self.ignore_errors is None or isinstance(self.ignore_errors, bool),
-             'ignore_errors must be either True of False'),
+             'ignore_errors must be a boolean (True or False)'),
             (self.skip_preview is None or isinstance(self.skip_preview, bool),
-             'skip_preview must be either True of False'),
+             'skip_preview must be a boolean (True or False)'),
             (self.pixel_subset is None or isinstance(self.pixel_subset, bool),
-             'pixel_subset must be either True of False')
+             'pixel_subset must be a boolean (True or False)')
         ]
 
     def _shape_error_messages(self, shape) -> List[str]:

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -369,3 +369,19 @@ def test_valid_get_jobs_request_with_multiple_labels_in_string():
 def test_get_jobs_request_with_invalid_argument():
     with pytest.raises(TypeError, match=".*got an unexpected keyword argument 'page_num'"):
         JobsRequest(page_num=1)
+
+def test_request_with_pixel_subset_false():
+    request = Request(collection=Collection('foobar'), pixel_subset=False)
+    assert request.is_valid()
+    assert request.pixel_subset is not None and request.pixel_subset == False
+
+
+def test_request_with_pixel_subset_true():
+    request = Request(collection=Collection('foobar'), pixel_subset=True)
+    assert request.is_valid()
+    assert request.pixel_subset is not None and request.pixel_subset == True
+
+
+def test_request_defaults_to_pixel_subset_none():
+    request = Request(collection=Collection('foobar'))
+    assert request.pixel_subset is None

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -385,3 +385,9 @@ def test_request_with_pixel_subset_true():
 def test_request_defaults_to_pixel_subset_none():
     request = Request(collection=Collection('foobar'))
     assert request.pixel_subset is None
+
+def test_request_with_pixel_subset_invalid():
+    request = Request(collection=Collection('foobar'), pixel_subset='invalid')
+    messages = request.error_messages()
+    assert not request.is_valid()
+    assert 'pixel_subset must be either True of False' in messages

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -390,4 +390,4 @@ def test_request_with_pixel_subset_invalid():
     request = Request(collection=Collection('foobar'), pixel_subset='invalid')
     messages = request.error_messages()
     assert not request.is_valid()
-    assert 'pixel_subset must be either True of False' in messages
+    assert 'pixel_subset must be a boolean (True or False)' in messages


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2035

## Description
This PR is the harmony-py part to support client requesting pixel subsetting. There is a corresponding harmony PR that should be used to test the harmony-py change.
It adds a new `pixel_subset` parameter in  harmony-py request to support pixel subsetting.

## Local Test Steps
The `pixel_subset` parameter can be unset, `True` or `False` in a harmony-py request. Feel free to experiment with different values in the following tests.

Use the following block to test OGC Rangeset requests:
```
import helper
helper.install_project_and_dependencies('..', libs=['examples'])
import json
import sys
import datetime as dt
from harmony import BBox, Client, Collection, Request, Environment

harmony_client = Client(env=Environment.LOCAL)
collection = Collection(id='C1233800302-EEDTEST')
request = Request(
    collection=collection,
    spatial=BBox(-140, 20, -50, 60),
    granule_id='G1233800343-EEDTEST',
    crs='EPSG:31975',
    variables=['blue_var'],
    format='image/png',
    pixel_subset=True
)

url = harmony_client.request_as_url(request)
print(url)

job_id = harmony_client.submit(request)

for filename in [f.result() for f in harmony_client.download_all(job_id)]:
    print(f'\nDownload file: {filename}')
```

Use the following block to test OGC EDR requests:
```
import helper
helper.install_project_and_dependencies('..', libs=['examples'])
import json
import sys
import datetime as dt
from harmony import WKT, BBox, Client, Collection, Request, Environment

harmony_client = Client(env=Environment.LOCAL)
collection = Collection(id='C1233800302-EEDTEST')

request = Request(
    collection=collection,
    spatial=WKT('POLYGON((-140 20, -50 20, -50 60, -140 60, -140 20))'),
    granule_id=['C1233800302-EEDTEST'],
    max_results=1,
    temporal={
        'start': dt.datetime(1980, 1, 1),
        'stop': dt.datetime(2020, 12, 30)
    },
    variables=['blue_var'],
    crs='EPSG:31975',
    format='image/png',
    pixel_subset=False
)

url = harmony_client.request_as_url(request)
print(url)

job_id = harmony_client.submit(request)
for filename in [f.result() for f in harmony_client.download_all(job_id)]:
    print(f'\nDownload file: {filename}')
```

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)