### PR TITLE
HARMONY-2076: Add support for the serviceId query parameter for OGC coverages and EDR requests.

### DIFF
--- a/harmony/request.py
+++ b/harmony/request.py
@@ -287,6 +287,9 @@ class Request(OgcBaseRequest):
 
         pixel_subset: Whether to perform pixel subset
 
+        service_id: The CMR UMM-S concept ID or service chain name to invoke. Only supported in
+          test environments for testing collections not yet associated with a service.
+
     Returns:
         A Harmony Transformation Request instance
     """
@@ -316,7 +319,8 @@ class Request(OgcBaseRequest):
                  ignore_errors: bool = None,
                  grid: str = None,
                  labels: List[str] = None,
-                 pixel_subset: bool = None):
+                 pixel_subset: bool = None,
+                 service_id: str = None):
         """Creates a new Request instance from all specified criteria.'
         """
         super().__init__(collection=collection)
@@ -343,6 +347,7 @@ class Request(OgcBaseRequest):
         self.grid = grid
         self.labels = labels
         self.pixel_subset = pixel_subset
+        self.service_id = service_id
 
         if self.is_edr_request():
             self.variable_name_to_query_param = {
@@ -366,6 +371,7 @@ class Request(OgcBaseRequest):
                 'variables': 'parameter-name',
                 'labels': 'label',
                 'pixel_subset': 'pixelSubset',
+                'service_id': 'serviceId',
             }
             self.spatial_validations = [
                 (lambda s: is_wkt_valid(s.wkt), f'WKT {spatial.wkt} is invalid'),
@@ -392,6 +398,7 @@ class Request(OgcBaseRequest):
                 'variables': 'variable',
                 'labels': 'label',
                 'pixel_subset': 'pixelSubset',
+                'service_id': 'serviceId'
             }
 
             self.spatial_validations = [

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -391,3 +391,9 @@ def test_request_with_pixel_subset_invalid():
     messages = request.error_messages()
     assert not request.is_valid()
     assert 'pixel_subset must be a boolean (True or False)' in messages
+
+
+def test_request_with_service_id():
+    request = Request(collection=Collection('foobar'), service_id='S123-PROV')
+    assert request.is_valid()
+    assert request.service_id == 'S123-PROV'


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2076

## Description
Add support for the serviceId query parameter for OGC coverages and EDR requests.

## Local Test Steps
Verify that executing this code sends the request to the `harmony/download` service chain instead of the `nasa/harmony-gdal-adapter` service chain (verify by going to the SIT workflow UI https://harmony.sit.earthdata.nasa.gov/workflow-ui)

```
from harmony import BBox, Client, Collection, Request, Environment
import datetime as dt
from IPython.display import JSON

harmony_client = Client(env=Environment.SIT)

collection = Collection(id='C1234088182-EEDTEST')

request = Request(
    collection=collection,
    spatial=BBox(-165, 52, -140, 77),
    temporal={
        'start': dt.datetime(2010, 1, 1),
        'stop': dt.datetime(2020, 12, 30)
    },
    variables=['blue_var'],
    max_results=10,
    crs='EPSG:3995',
    format='image/tiff',
    height=512,
    width=512,
    service_id='harmony/download'
)

job_id = harmony_client.submit(request)
JSON(harmony_client.status(job_id))
```

You can also test changing the service_id to an invalid value and verify that an error is returned.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)