### PR TITLE
HARMONY-2166: Added average parameter to request.py

### DIFF
--- a/harmony/request.py
+++ b/harmony/request.py
@@ -269,6 +269,8 @@ class Request(OgcBaseRequest):
 
         concatenate: Whether to invoke a service that supports concatenation
 
+        average: the type of averaging to perform
+
         skip_preview: Whether Harmony should skip auto-pausing and generating a preview for
           large jobs
 
@@ -315,6 +317,7 @@ class Request(OgcBaseRequest):
                  variables: List[str] = ['all'],
                  width: int = None,
                  concatenate: bool = None,
+                 average: str = None,
                  skip_preview: bool = None,
                  ignore_errors: bool = None,
                  grid: str = None,
@@ -342,6 +345,7 @@ class Request(OgcBaseRequest):
         self.variables = variables
         self.width = width
         self.concatenate = concatenate
+        self.average = average
         self.skip_preview = skip_preview
         self.ignore_errors = ignore_errors
         self.grid = grid
@@ -391,6 +395,7 @@ class Request(OgcBaseRequest):
                 'format': 'format',
                 'max_results': 'maxResults',
                 'concatenate': 'concatenate',
+                'average': 'average',
                 'skip_preview': 'skipPreview',
                 'ignore_errors': 'ignoreErrors',
                 'grid': 'grid',

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -397,3 +397,9 @@ def test_request_with_service_id():
     request = Request(collection=Collection('foobar'), service_id='S123-PROV')
     assert request.is_valid()
     assert request.service_id == 'S123-PROV'
+
+
+def test_request_with_average():
+    request = Request(collection=Collection('foobar'), average='time')
+    assert request.is_valid()
+    assert request.average == 'time'


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2166

## Description
Added the 'average' parameter, which is used by the Cloud Giovanni averaging service, to request.py. I wasn't sure if this needed an update to unit tests or not. The 'average' parameter is not validated because it will expand beyond the current two options. I checked your request.py tests and I don't see a test for 'variable', which is similarly not validated in the request.py module, so I decided that meant you didn't need a test. Please let me know if this is incorrect.

I wasn't sure how to handle documentation since this service isn't in production yet.

## Local Test Steps
The averaging service is only in UAT at this time, so you'll need to make the request against that baseline.

```
from harmony import Dimension, Client, Collection, Request, Environment
import datetime as dt
import os

harmony_client = Client(env=Environment.UAT)
collection=Collection(id='C1240560361-GES_DISC')
request = Request(
    collection=collection,
    temporal={'start':dt.datetime(2010,1,1),'stop':dt.datetime(2010,1,2)},
    dimensions=[Dimension('lat',40,41),Dimension('lon',-120,-119)],
    variables=['GPM_3IMERGHH_07_precipitation'],
    format='image/tiff',
    average='time'
)

job_id = harmony_client.submit(request)
results = harmony_client.download_all(job_id,directory='/tmp')
for r in results:
    filepath=r.result()
    assert os.path.exists(filepath)
```

## PR Acceptance Checklist
* [ ] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)