### PR TITLE
HARMONY-2168: Make sure the environment variable ENVIRONMENT does not override the harmony environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,9 @@ dmypy.json
 examples/*.tif
 examples/*.png
 
+# Place to put notebooks that will not be published
+examples/demo_notebooks/
+
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/
 

--- a/harmony/config.py
+++ b/harmony/config.py
@@ -93,7 +93,7 @@ class Config:
             The value of the referenced attribute
         """
         var = os.getenv(name.upper())
-        if var is None:
+        if var is None or name == 'environment':
             try:
                 var = object.__getattribute__(self, name)
             except AttributeError:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,6 +14,7 @@ import responses
 from harmony.request import BBox, Collection, LinkType, Request, Dimension, CapabilitiesRequest, \
     AddLabelsRequest, DeleteLabelsRequest, JobsRequest
 from harmony.client import Client, ProcessingFailedException, DEFAULT_JOB_LABEL
+from harmony.config import Environment
 
 
 @pytest.fixture()
@@ -1827,3 +1828,21 @@ def test_get_jobs():
     assert responses.calls[0].request.method == 'GET'
     assert responses.calls[0].request.url == expected_url
     assert result == expected_result
+
+def test_client_environment_not_affected_by_env_var():
+    os.environ['ENVIRONMENT'] = 'UAT'
+    client = Client(should_validate_auth=False)
+
+    assert client.config.environment == Environment.PROD
+    assert client.config.harmony_hostname == 'harmony.earthdata.nasa.gov'
+
+    del os.environ['ENVIRONMENT']
+
+def test_client_custom_environment_not_affected_by_env_var():
+    os.environ['ENVIRONMENT'] = 'PROD'
+    client = Client(should_validate_auth=False, env=Environment.UAT)
+
+    assert client.config.environment == Environment.UAT
+    assert client.config.harmony_hostname == 'harmony.uat.earthdata.nasa.gov'
+
+    del os.environ['ENVIRONMENT']

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 
 from harmony.config import Config, Environment
 
@@ -78,3 +79,31 @@ def test_edl_validation_url_matches_environment(env, url):
     config = Config(env)
 
     assert config.edl_validation_url == url
+
+def test_config_environment_not_affected_by_env_var():
+    os.environ['ENVIRONMENT'] = 'UAT'
+
+    # Make sure default is production
+    config = Config()
+
+    assert config.environment == Environment.PROD
+    assert config.harmony_hostname == 'harmony.earthdata.nasa.gov'
+
+    del os.environ['ENVIRONMENT']
+
+def test_config_custom_environment_not_affected_by_env_var():
+    os.environ['ENVIRONMENT'] = 'PROD'
+    config = Config(environment=Environment.UAT)
+
+    assert config.environment == Environment.UAT
+    assert config.harmony_hostname == 'harmony.uat.earthdata.nasa.gov'
+
+    del os.environ['ENVIRONMENT']
+
+def test_config_other_env_vars_still_work():
+    os.environ['CUSTOM_VAR'] = 'test_value'
+    config = Config()
+
+    assert config.CUSTOM_VAR == 'test_value'
+
+    del os.environ['CUSTOM_VAR']


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2168

Fixes #116 

## Description
When constructing a Harmony Client the ENVIRONMENT env var was incorrectly overriding the desired harmony environment. This PR changes the code to ignore the ENVIRONMENT env var so that the behavior is to use the environment passed into the client constructor or default to production if no environment is passed in.

## Local Test Steps
This should fail on the main branch but pass in this branch.

```
import os

os.environ['ENVIRONMENT'] = 'foo'
harmony_client = Client() 

assert harmony_client.config.environment == Environment.PROD
assert harmony_client.config.harmony_hostname == 'harmony.earthdata.nasa.gov'
```

You can test other combinations like `harmony_client = Client(should_validate_auth=False, env=Environment.UAT)` as well.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)