### PR TITLE
Removes backoff_jitter from the Retry configuration.

### DIFF
--- a/harmony/client.py
+++ b/harmony/client.py
@@ -170,7 +170,6 @@ class Client:
             retry_strategy = Retry(
                 total=3,
                 backoff_factor=1,  # Wait 1, 2, 4 seconds between retries
-                backoff_jitter=0.5,
                 status_forcelist=[429, 500, 502, 503, 504],
                 allowed_methods=["GET"],
                 raise_on_status=False,


### PR DESCRIPTION
## Jira Issue ID
None

## Description
Removes backoff_jitter from the Retry() call.

This keyword was added to urllib3 in v2.0.0. Some users are running into issues, unable to initialize a Client with urllib3 < 2. 

I don't want to dig around to handle multiple library versions. I'm proposing to just nuke this option. 

### Error case

```
❯ python
Python 3.12.12 | packaged by conda-forge | (main, Oct 22 2025, 23:34:53) [Clang 19.1.7 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import urllib3
>>> urllib3.__version__
'1.26.20'
>>> import harmony
>>> harmony.__version__
'1.3.2'
>>> harmony.Client()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/savoie/.pyenv/versions/miniforge3-24.3.0-0/envs/nsidc-tutorials/lib/python3.12/site-packages/harmony/client.py", line 160, in __init__
    validate_auth(self.config, self._session())
                               ^^^^^^^^^^^^^^^
  File "/Users/savoie/.pyenv/versions/miniforge3-24.3.0-0/envs/nsidc-tutorials/lib/python3.12/site-packages/harmony/client.py", line 170, in _session
    retry_strategy = Retry(
                     ^^^^^^
TypeError: Retry.__init__() got an unexpected keyword argument 'backoff_jitter'
```

### Success case (after installing this branch's built package)

```
Python 3.12.12 | packaged by conda-forge | (main, Oct 22 2025, 23:34:53) [Clang 19.1.7 ] on darwin
>>> import urllib3
>>> urllib3.__version__
'1.26.20'
```
```
❯ pip install ../data-services/harmony-py/dist/harmony_py-1.3.2+1.gde0d5a8-py3-none-any.whl
Processing /Users/savoie/projects/data-services/harmony-py/dist/harmony_py-1.3.2+1.gde0d5a8-py3-none-any.whl
(snip)
Successfully installed harmony-py-1.3.2+1.gde0d5a8 python-dotenv-1.1.1
```

```
❯ python
Python 3.12.12 | packaged by conda-forge | (main, Oct 22 2025, 23:34:53) [Clang 19.1.7 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import harmony
>>> harmony.Client()
<harmony.client.Client object at 0x1029e7c50>
>>>
```

## Local Test Steps
 
Run Tests. 🤞 

Build this package, create an environment with urllib3<2, install the package and instantiate a Request() object like demonstrated above.




## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] ~Tests added/updated (if needed) and passing~
* [ ] ~Documentation updated (if needed)~