### PR TITLE
Add links to ReadTheDocs and example tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This will install harmony-py and its dependencies into your current Python envir
 
 Looking for examples of harmony-py in action? Check out these resources:
 
-* **[Example Jupyter Notebooks](examples/)** - In this repository, see the `examples/` directory for hands-on tutorials
+* **[Example Jupyter Notebooks](https://github.com/nasa/harmony-py/tree/main/examples)** - In this repository, see the `examples/` directory for hands-on tutorials
 * **[TEMPO Atmospheric Data Tutorial](https://nasa.github.io/ASDC_Data_and_User_Services/TEMPO/how_to_examine_TEMPO_data_using_harmony-py.html)** - Learn how to access and analyze TEMPO data from NASA's ASDC using harmony-py
 * **[Subsetting NASA Earthdata Using Harmony](https://nasa-openscapes.github.io/earthdata-cloud-cookbook/tutorials/Harmony.html)** - Tutorial on requesting spatial and temporal subsets of ICESat-2 data using harmony-py
 


### PR DESCRIPTION
## Description

This PR addresses issue #114 by adding links to the ReadTheDocs documentation and real-world example tutorials to improve discoverability for new users.

Fixes #114

## Changes Made

- **Added Documentation section**: Prominent link to [ReadTheDocs API documentation](https://harmony-py.readthedocs.io/en/latest/) right after the intro section
- **Added Examples & Tutorials section**: New section with links to:
  - Local example Jupyter notebooks in the repository
  - [TEMPO atmospheric data tutorial](https://nasa.github.io/ASDC_Data_and_User_Services/TEMPO/how_to_examine_TEMPO_data_using_harmony-py.html) from NASA's ASDC cookbook
  - [ICESat-2 tutorial](https://nasa-openscapes.github.io/earthdata-cloud-cookbook/tutorials/IS2_Harmony.html) from the Openscapes cloud cookbook
