### PR TITLE
Relax shapely pin to >=2.0.4,<3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "requests ~= 2.32.3",
     "sphinxcontrib-napoleon ~= 0.7",
     "curlify ~= 2.2.1",
-    "shapely ~= 2.0.4"
+    "shapely >=2.0.4,<3"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1837 ?

## Description

Allow harmony-py to be compatible with other libraries that require shapely 2.1.x. Fixes #79.

## Local Test Steps

A search using https://github.com/search?q=repo%3Anasa%2Fharmony-py%20shapely&type=code shows that only [`shapely.lib.ShapelyError`](https://github.com/shapely/shapely/blob/2.1.2/shapely/errors.py#L5) and [`shapely.wkt.loads`](https://shapely.readthedocs.io/en/2.1.2/manual.html#shapely.wkt.loads) are used, which should be compatible across shapely 2.0.x and 2.1.x

## PR Acceptance Checklist
* [ ] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)