### PR TITLE
Improve error message when submit fails due to missing EDL credentials

### DIFF
--- a/harmony/client.py
+++ b/harmony/client.py
@@ -545,10 +545,20 @@ class Client:
 
         if response.ok:
             if isinstance(request, OgcBaseRequest):
-                if response.json()['status'] == 'successful':
-                    return response.json()
+                try:
+                    response_json = response.json()
+                except requests.exceptions.JSONDecodeError:
+                    raise Exception(
+                        'Harmony returned an empty or non-JSON response. '
+                        'This usually means your Earthdata Login credentials are missing or '
+                        'incorrect. Ensure your ~/.netrc file contains a valid entry for '
+                        f'{self.config.root_url} and urs.earthdata.nasa.gov, or pass '
+                        "auth=('username', 'password') when creating the Client."
+                    ) from None
+                if response_json['status'] == 'successful':
+                    return response_json
                 else:
-                    return response.json()['jobID']
+                    return response_json['jobID']
             else:
                 try:
                     return response.json()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1602,6 +1602,30 @@ def test_handle_error_response_invalid_json():
     assert len(responses.calls) == 9 # (1 + 4 + 4)
 
 @responses.activate
+def test_submit_raises_helpful_auth_error_on_empty_response():
+    """When the server returns 200 with empty/HTML body (EDL auth redirect),
+    the user should see a clear message about .netrc credentials rather than
+    a raw JSONDecodeError."""
+    collection = Collection(id='C1940468263-POCLOUD')
+    request = Request(
+        collection=collection,
+        spatial=BBox(-107, 40, -105, 42)
+    )
+    responses.add(
+        responses.POST,
+        expected_submit_url(collection.id),
+        status=200,
+        body=b'',
+        content_type='text/html',
+    )
+    with pytest.raises(Exception) as exc_info:
+        Client(should_validate_auth=False).submit(request)
+    error_msg = str(exc_info.value)
+    assert 'netrc' in error_msg
+    assert 'urs.earthdata.nasa.gov' in error_msg
+
+
+@responses.activate
 def test_handle_non_transient_error_no_retry():
     job_id = '89733-badc-1324'
     collection = Collection(id='F229040468263-STRP')


### PR DESCRIPTION
Fixes #129.

## Problem

When `harmony_client.submit()` is called and the user has a missing or incorrect `~/.netrc` entry for `urs.earthdata.nasa.gov`, the Earthdata Login service redirects the request and returns an empty or HTML response body. Because the `OgcBaseRequest` branch in `submit()` called `response.json()` with no exception handling, this surfaced as a raw `JSONDecodeError` with no hint of the actual cause.

The non-`OgcBaseRequest` path already had a `try/except` for `JSONDecodeError` (line 553) — the `OgcBaseRequest` path was missing the same guard.

## Changes

- Wrap the `response.json()` call in the `OgcBaseRequest` branch with a `try/except JSONDecodeError` that raises a clear `Exception` pointing to `.netrc` configuration and `urs.earthdata.nasa.gov`.
- Added `test_submit_raises_helpful_auth_error_on_empty_response` following the existing `@responses.activate` test pattern.

## Before

```
JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

## After

```
Exception: Harmony returned an empty or non-JSON response. This usually means your
Earthdata Login credentials are missing or incorrect. Ensure your ~/.netrc file contains
a valid entry for https://harmony.earthdata.nasa.gov and urs.earthdata.nasa.gov, or pass
auth=('username', 'password') when creating the Client.
```

## Checks run

- `pytest tests/test_client.py -q` — passed (new test + all existing)