### PR TITLE
HARMONY-1837 Relax dependency upper bounds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       always() &&
-      github.event_name == 'schedule' &&
+      (github.event_name == 'schedule' ||
+       github.event_name == 'workflow_dispatch') &&
       needs.build.result == 'failure'
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,7 @@ name: Tests
 on:
   push:
   pull_request:
+  workflow_dispatch: # for testing remove
   schedule:
     # Nightly run at 02:00 UTC — catches breakage from new upstream releases
     - cron: '0 2 * * *'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,10 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         dependencies: ['minimum', 'latest']
+      exclude:
+        # shapely 2.0.4 has no pre-build wheel for 3.13
+        - python-version: '3.13'
+          dependencies: 'minimum'
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    # Nightly run at 02:00 UTC
-    - cron: '0 2 * * *'
+    - cron: '0 2 * * 1,3,5'
 
 jobs:
   build:
@@ -40,7 +39,7 @@ jobs:
         path: htmlcov/*
       if: ${{ github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize') }}
 
-  notify_failure:
+  notify_nightly_failure:
     needs: build
     runs-on: ubuntu-latest
     if: >

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,11 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    # Nightly run at 02:00 UTC — catches breakage from new upstream releases
+    - cron: '0 2 * * *'
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    # Nightly run at 02:00 UTC — catches breakage from new upstream releases
+    # Nightly run at 02:00 UTC
     - cron: '0 2 * * *'
 
 jobs:
@@ -40,7 +40,7 @@ jobs:
         path: htmlcov/*
       if: ${{ github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize') }}
 
-  notify:
+  notify_failure:
     needs: build
     runs-on: ubuntu-latest
     if: >
@@ -48,15 +48,34 @@ jobs:
       needs.build.result == 'failure'
 
     steps:
-      - name: Create issue
+      - name: Create or comment on issue
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.issues.create({
+            const title = 'Nightly tests failed';
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Nightly tests failed`,
-              body: `The nightly scheduled test run failed.
+              state: 'open',
+              per_page: 100,
+            });
 
-              Run: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
-            })
+            const existing = issues.find(i => i.title === title);
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body: `Nightly run failed again.\n\nRun: ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body: `The nightly scheduled test run failed.\n\nRun: ${runUrl}`,
+              });
+            }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   push:
   pull_request:
-  workflow_dispatch: # for testing remove
+  workflow_dispatch:
   schedule:
     # Nightly run at 02:00 UTC — catches breakage from new upstream releases
     - cron: '0 2 * * *'
@@ -43,8 +43,6 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       always() &&
-      (github.event_name == 'schedule' ||
-       github.event_name == 'workflow_dispatch') &&
       needs.build.result == 'failure'
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       always() &&
-      needs.build.result == 'failure'
+      needs.build.result == 'failure' &&
       github.event_name == 'schedule'
     steps:
       - name: Notify Slack

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,3 +36,25 @@ jobs:
         name: code-coverage-report ${{ github.event.pull_request.head.sha }} ${{ matrix.python-version }}
         path: htmlcov/*
       if: ${{ github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize') }}
+
+  notify:
+    needs: build
+    runs-on: ubuntu-latest
+    if: >
+      always() &&
+      github.event_name == 'schedule' &&
+      needs.build.result == 'failure'
+
+    steps:
+      - name: Create issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Nightly tests failed`,
+              body: `The nightly scheduled test run failed.
+
+              Run: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            })

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: Tests
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,11 +10,13 @@ on:
     - cron: '0 2 * * 1,3,5'
 
 jobs:
+
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        dependencies: ['minimum', 'latest']
 
     steps:
     - uses: actions/checkout@v4
@@ -24,7 +26,13 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
+    - name: Install minimum pinned dependencies
+      if: matrix.dependencies == 'minimum'
+      run: |
+        make install-minimum
+
+    - name: Install latest dependencies
+      if: matrix.dependencies == 'latest'
       run: |
         make install
 
@@ -40,11 +48,12 @@ jobs:
       if: ${{ github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize') }}
 
   notify_nightly_failure:
-    needs: build
+    needs:
+      - build
     runs-on: ubuntu-latest
     if: >
       always() &&
-      needs.build.result == 'failure' &&
+      needs.build.result == 'failure'
       github.event_name == 'schedule'
     steps:
       - name: Notify Slack

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,37 +45,15 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       always() &&
-      needs.build.result == 'failure'
-
+      needs.build.result == 'failure' &&
+      github.event_name == 'schedule'
     steps:
-      - name: Create or comment on issue
-        uses: actions/github-script@v7
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@v3
         with:
-          script: |
-            const title = 'Nightly tests failed';
-            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-
-            const { data: issues } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              per_page: 100,
-            });
-
-            const existing = issues.find(i => i.title === title);
-
-            if (existing) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: existing.number,
-                body: `Nightly run failed again.\n\nRun: ${runUrl}`,
-              });
-            } else {
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title,
-                body: `The nightly scheduled test run failed.\n\nRun: ${runUrl}`,
-              });
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "❌ Nightly tests failed: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
             }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Notify Slack
         uses: slackapi/slack-github-action@v3
         with:
+          # https://api.slack.com/apps (to create app to receive webook)
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,10 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         dependencies: ['minimum', 'latest']
-      exclude:
-        # shapely 2.0.4 has no pre-build wheel for 3.13
-        - python-version: '3.13'
-          dependencies: 'minimum'
+        exclude:
+          # shapely 2.0.4 has no pre-build wheel for 3.13
+          - python-version: '3.13'
+            dependencies: 'minimum'
 
     steps:
     - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ install:
 	pip install .
 	pip install .[dev,docs]
 
+install-minimum:
+	python -m pip install --upgrade pip
+	pip install -r requirements-min.txt
+	pip install .[dev,docs] --constraint requirements-min.txt
+
 install-examples: install
 	pip install .[examples]
 

--- a/harmony/request.py
+++ b/harmony/request.py
@@ -216,11 +216,8 @@ def is_wkt_valid(wkt_string: str) -> bool:
         # Attempt to load the WKT string
         loads(wkt_string)
         return True
-    except (ShapelyError, ValueError) as e:
+    except (ShapelyError, ValueError, NotImplementedError) as e:
         # Handle WKT reading errors and invalid WKT strings
-        print(f"Invalid WKT: {e}")
-        return False
-    except (ShapelyError, NotImplementedError) as e:
         print(f"Invalid WKT: {e}")
         return False
 

--- a/harmony/request.py
+++ b/harmony/request.py
@@ -220,6 +220,9 @@ def is_wkt_valid(wkt_string: str) -> bool:
         # Handle WKT reading errors and invalid WKT strings
         print(f"Invalid WKT: {e}")
         return False
+    except (ShapelyError, NotImplementedError) as e:
+        print(f"Invalid WKT: {e}")
+        return False
 
 
 class Request(OgcBaseRequest):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "python-dotenv >=1.1.0",
     "progressbar2 >=4.2.0",
     "requests >=2.32.3",
-    "sphinxcontrib-napoleon >=0.7",
     "curlify >=2.2.1",
     "shapely >=2.0.4"
 ]
@@ -62,6 +61,7 @@ docs = [
     "nbconvert ~= 7.10.0",
     "progressbar2 ~= 4.2.0",
     "sphinx ~= 7.1.2",
+    "sphinxcontrib-napoleon ~= 0.7",
     "sphinx-rtd-theme ~= 1.3.0",
     "shapely ~= 2.0.4"
 ]
@@ -89,4 +89,3 @@ exclude = ["contrib", "docs", "tests*"]
 [tool.flake8]
 max-line-length = 99
 ignore = ["F401", "W503"]
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
 ]
 dynamic = ["version"]
+
+# If you change these dependencies, make sure you also update the
+# requirements-min.txt file with a pinned version for testing.
 dependencies = [
     "python-dateutil >=2.9",
     "python-dotenv >=1.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,13 +29,13 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "python-dateutil ~= 2.9",
-    "python-dotenv ~= 1.1.0",
-    "progressbar2 ~= 4.2.0",
-    "requests ~= 2.32.3",
-    "sphinxcontrib-napoleon ~= 0.7",
-    "curlify ~= 2.2.1",
-    "shapely >=2.0.4,<3"
+    "python-dateutil >=2.9",
+    "python-dotenv >=1.1.0",
+    "progressbar2 >=4.2.0",
+    "requests >=2.32.3",
+    "sphinxcontrib-napoleon >=0.7",
+    "curlify >=2.2.1",
+    "shapely >=2.0.4"
 ]
 
 [project.urls]

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,0 +1,6 @@
+python-dateutil==2.9.0
+python-dotenv==1.1.0
+progressbar2==4.2.0
+requests==2.32.3
+curlify==2.2.1
+shapely==2.0.4

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,3 +1,7 @@
+# Minimum version constraint file for CI/CD testing This file should contain
+# pinned versions of the mimimum bounds from pyproject.toml's dependencies
+# block.
+
 python-dateutil==2.9.0
 python-dotenv==1.1.0
 progressbar2==4.2.0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1396,6 +1396,8 @@ def side_effect_for_get_json_failed_job(extra_links) -> List[str]:
 def test_iterator_failed_job(link_type, mocker):
     # test with two successful work items followed by a failed job
     extra_links = extra_links_for_iteration(link_type.value)
+    download_file_mock = mocker.Mock(side_effect=side_effect_func_for_download_file)
+    mocker.patch('harmony.client.Client._download_file', download_file_mock)
     get_json_mock = mocker.Mock(
         side_effect=side_effect_for_get_json_failed_job(extra_links=extra_links))
     mocker.patch('harmony.client.Client._get_json', get_json_mock)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1383,7 +1383,7 @@ def test_iterator(link_type, mocker):
 
 # this function provides a different value for subsequent calls to _get_json to simulate
 # changing status page - in this case the status changes from 'running' to 'failed'
-def side_effect_for_get_json_failed_job(extra_links) -> List[str]:
+def side_effect_for_get_json_failed_job(extra_links) -> List[dict]:
     status_running = expected_job('C123', 'foo123')
     status_running['links'].append(extra_links[0])
     status_failed = copy.deepcopy(status_running)

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -421,3 +421,6 @@ def test_request_with_average():
     request = Request(collection=Collection('foobar'), average='time')
     assert request.is_valid()
     assert request.average == 'time'
+
+def test_failure_creates_issue():
+    assert False

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -421,6 +421,3 @@ def test_request_with_average():
     request = Request(collection=Collection('foobar'), average='time')
     assert request.is_valid()
     assert request.average == 'time'
-
-def test_failure_creates_issue():
-    assert False


### PR DESCRIPTION
## Description 

This PR pulls in the user contribution changes for #132 

This will close #79 and HARMONY-1837

Code Changes: 
 - Unpins top bounds on dependencies.
 - Adds new requirements-min.txt to test minimum requirements
 - Updates the workflow to test both latest and minimum requirements
 - adds an install-minimum to the Makefile to constrain the package install to the pinned values.


Workflow changes: Adds a notify_nightly_failure task that will post a message to a slack webhook. Right now that webhook is configured to an NSIDC channel that I will listen to, but I have requested an app be created in the NASA org that we can use to post to #dev-harmony-only 




