### PR TITLE
Improvement: Switch to git tags for version during packaging.

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,25 +15,8 @@ jobs:
       with:
         python-version: '3.11'
     - shell: bash
-      env:
-        VERSION_TAG: ${{ github.event.release.tag_name }}
-        BRANCH: ${{ github.event.release.target_commitish }}
-      run: |
-        VERSION=$(echo "${VERSION_TAG}" | cut -c2-) make install build
-
-        # Setup git
-        # https://api.github.com/users/github-actions%5Bbot%5D
-        git config --global user.name "github-actions[bot]"
-        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-        # Commit and push updated release files
-        git checkout -b "${BRANCH}"
-        git add .
-        git commit -m "Update release version to ${VERSION_TAG}"
-        git push origin "${BRANCH}"
-
-        git tag --force "${VERSION_TAG}"
-        git push --force origin "${VERSION_TAG}"
+      # Version is derived from the release tag by setuptools_scm (needs fetch-depth: 0 above).
+      run: make install build
     - name: upload dists
       uses: actions/upload-artifact@v4
       with:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 .PHONY: install install-examples clean examples lint test test-watch ci docs
 
-VERSION ?= $(shell git describe --tags | sed 's/-/\+/' | sed 's/-/\./g')
 REPO ?= https://upload.pypi.org/legacy/
 REPO_USER ?= __token__
 REPO_PASS ?= unset
@@ -47,10 +46,7 @@ docs/user/notebook.html: $(docs-notebook)
 docs: docs/user/notebook.html
 	cd docs && $(MAKE) html
 
-version:
-	sed -i.bak "s/__version__ .*/__version__ = \"$(VERSION)\"/" harmony/__init__.py && rm harmony/__init__.py.bak
-
-build: clean version
+build: clean
 	python -m pip install --upgrade --quiet setuptools wheel twine build
 	python -m build
 

--- a/harmony/__init__.py
+++ b/harmony/__init__.py
@@ -1,5 +1,9 @@
-# Automatically updated by `make build`
-__version__ = "1.4.0"
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("harmony-py")
+except PackageNotFoundError:  # running from a source tree that was never installed
+    __version__ = "0.0.0+unknown"
 
 from harmony.config import Environment
 from harmony.request import BBox, WKT, Collection, LinkType, Dimension, Request, \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # https://pypi.org/pypi?%3Aaction=list_classifiers
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -82,9 +82,8 @@ examples = [
     "rasterio ~= 1.3"
 ]
 
-[tool.setuptools.dynamic]
-# Will read __version__ from harmony.__init__.py
-version = {attr = "harmony.__version__"}
+[tool.setuptools_scm]
+# Version is derived from the git tag (e.g. v1.4.0 -> 1.4.0) at build time.
 
 [tool.setuptools.packages.find]
 exclude = ["contrib", "docs", "tests*"]


### PR DESCRIPTION
## Jira Issue ID

HARMONY-FIX

## Description

Derive the package version from the git tag at build time usind `setuptools_scm`
so releases no longer require CI to bump and force push to `main`.

This will allow us to add branch protections to the default branch without
having to add an application to add an exception to the rules. And we can keep
the same basic workflow.

Note: `harmony/__init__.py` will no longer have a literal version string.

## Local Test Steps

This is a little tough to test, but you can do a few things.

You check out this commit and build the package with `make build`

You will get:
```
Successfully built harmony_py-1.4.1.dev1+gac794a9bf.tar.gz and harmony_py-1.4.1.dev1+gac794a9bf-py3-none-any.whl
```

so `+gac794a9bf` == built from git commit.



Or you can use a pretend version:
```
❯ SETUPTOOLS_SCM_PRETEND_VERSION=2.4.0 make build
```

and get
```
Successfully built harmony_py-2.4.0.tar.gz and harmony_py-2.4.0-py3-none-any.whl
```

you can check the `harmony.__version__` still works on either of these by installing the wheel and checking the version

```
❯ python -c "import harmony; print(harmony.__version__)"
```

You can actually fake install any version with the make command:
```
❯ SETUPTOOLS_SCM_PRETEND_VERSION=3.0.3 make install
```
...Successfully installed harmony-py-3.0.3

```
❯ python -c "import harmony; print(harmony.__version__)"
3.0.3
```

The final way you can test how CI/CD will respond is by adding a local tag in the form v.X.Y.Z on the checked out branch with everything clean, then a make build will generate a vX.Y.Z package.



## PR Acceptance Checklist
* [ ] ~Acceptance criteria met~
* [ ] ~Tests added/updated (if needed) and passing~
* [ ] ~Documentation updated (if needed)~
