### PR TITLE
Fix #140: Correct download_all docstring to describe generator behavior

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,7 @@ Harmony-Py is a work-in-progress, is not feature complete, and should only be us
 
     >>> job_id = harmony_client.submit(request)
 
-    >>> harmony_client.download_all(job_id)
+    >>> filenames = [f.result() for f in client.download_all(job_id)]
 
 -------------------
 

--- a/examples/basic.ipynb
+++ b/examples/basic.ipynb
@@ -145,11 +145,11 @@
    "id": "threatened-complement",
    "metadata": {},
    "source": [
-    "There are a number of options available for downloading results. We'll start with the 'download_all()' method which uses a multithreaded downloader and quickly returns with a \"future\" (specifically a python conccurrent.futures future).\n",
+    "There are a number of options available for downloading results. We'll start with the 'download_all()' method which uses a multithreaded downloader and returns a **generator** of futures (specifically python concurrent.futures objects).\n",
     "\n",
-    "If you're unfamiliar with futures, at their most basic level they represent an eventual value. In our case, once a file is downloaded its future will contain the name of the local file. We can then hand the name off to other functions which open files based on their name to perform further operations. Work performed on behalf of each future takes place in a \"thread pool\" created for each Client instantiation.\n",
+    "If you're unfamiliar with futures, at their most basic level they represent an eventual value. In our case, once a file is downloaded its future will contain the name of the local file. We can then hand the name off to other functions which open files based on the filename.\n",
     "\n",
-    "To extract the eventual value of a future, call its 'result()' method. By using futures we can process downloaded files as soon as they're ready while the rest of the files are still downloading in the background. Because of how we're working with the futures, the order of our results are maintained even though the files will likely be downloaded out of order."
+    "**Important:** Because `download_all()` is a generator, downloads only begin when you iterate it. If you call `download_all()` but never iterate the result, no files will be downloaded. The simplest pattern is to use a list comprehension: `[f.result() for f in harmony_client.download_all(job_id)]`.\n"
    ]
   },
   {

--- a/examples/intro_tutorial.ipynb
+++ b/examples/intro_tutorial.ipynb
@@ -180,7 +180,7 @@
     "\n",
     "Other advanced parameters that may be of interest. Note that many reformatting or advanced projection options may not be available for your requested dataset. See the [documentation](https://harmony-py.readthedocs.io/en/latest/) for details on how to construct these parameters.\n",
     "\n",
-    "* `crs`: Reproject the output coverage to the given CRS. Recognizes CRS types that can be inferred by gdal, including EPSG codes, Proj4 strings, and OGC URLs (http://www.opengis.net/def/crs/…)\n",
+    "* `crs`: Reproject the output coverage to the given CRS. Recognizes CRS types that can be inferred by gdal, including EPSG codes, Proj4 strings, and OGC URLs (http://www.opengis.net/def/crs/\u2026)\n",
     "* `interpolation`: specify the interpolation method used during reprojection and scaling\n",
     "* `scale_extent`: scale the resulting coverage either among one axis to a given extent\n",
     "* `scale_size`: scale the resulting coverage either among one axis to a given size\n",
@@ -374,9 +374,9 @@
    "id": "1a46cae7",
    "metadata": {},
    "source": [
-    "The next code block utilizes `download_all()` to download all data output file URLs. This is a non-blocking step during the download itself, but this line will block subsequent code while waiting for the job to finish processing. You can optionally specify a directory and specify whether to overwrite existing files as shown below.\n",
+    "The next code block utilizes `download_all()` to download all data output file URLs. This call blocks while waiting for the job to finish processing, then returns a **generator** of future objects. You can optionally specify a directory and specify whether to overwrite existing files as shown below.\n",
     "\n",
-    "You may call `result()` on future objects (those that are awaiting processing) to realize them. A call to `result()` blocks until that particular future object finishes downloading. Other future objects will download in the background, in parallel. When downloading is complete, the future objects will return the file path string of the file that was just downloaded. This file path can then be fed into other libraries that may read the data files and perform other operations."
+    "**Important:** `download_all()` is a generator, meaning downloads only begin when you iterate it. If you assign the result to a variable but never iterate it, no files will be downloaded. You may call `result()` on each future object to block until that particular file finishes downloading. Other future objects will download in the background, in parallel. When downloading is complete, each future returns the file path string of the downloaded file, which can then be fed into other libraries that read the data files.\n"
    ]
   },
   {

--- a/examples/job_results.ipynb
+++ b/examples/job_results.ipynb
@@ -100,12 +100,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# 'download_all()' downloads all data urls and returns immediately with a list of concurrent.futures.\n",
+    "# 'download_all()' is a generator that yields concurrent.futures.Future objects, one per file.\n",
+    "# Downloads are lazy: they only begin when you iterate the generator.\n",
     "# Optionally shows progress bar for processing only.\n",
-    "# Non-blocking during download but blocking while waitinig for job processing to finish.\n",
-    "# Call 'result()' on future objects to realize them. A call to 'result()' blocks until that particular future finishes downloading. Other futures will download in the background, in parallel, up to the number of workers assigned to the thread pool (thread pool not publicly available).\n",
-    "# Downloading on any unfinished futures can be cancelled early.\n",
-    "# When downloading is complete the futures will return the file path string of the file that was just downloaded. This file path can then be fed into other libraries that may read the data files and perform other operations.\n",
+    "# Non-blocking during download but blocking while waiting for job processing to finish.\n",
+    "# Call 'result()' on each future to block until that file finishes downloading. Other futures\n",
+    "# will download in the background, in parallel, up to the number of workers in the thread pool.\n",
+    "# When complete, each future returns the file path string of the downloaded file.\n",
     "futures = harmony_client.download_all(job_id)\n",
     "file_names = [f.result() for f in futures]"
    ]

--- a/harmony/client.py
+++ b/harmony/client.py
@@ -1017,12 +1017,8 @@ class Client:
             Each Future resolves to the filename (with path) of the downloaded file.
 
         Example:
-            >>> # Download all files and wait for each to finish
-            >>> futures = harmony_client.download_all(job_id, directory='/tmp')
-            >>> file_names = [f.result() for f in futures]
-
-            >>> # Or collect the generator into a list first
-            >>> futures = list(harmony_client.download_all(job_id))
+            >>> # Consume the generator to submit downloads, then wait for completion
+            >>> futures = list(client.download_all(job_id, directory='/tmp'))
             >>> file_names = [f.result() for f in futures]
         """
         if isinstance(job_id_or_result_json, str):

--- a/harmony/client.py
+++ b/harmony/client.py
@@ -962,7 +962,13 @@ class Client:
             files from incomplete downloads, set overwrite to True.
 
         Returns:
-            A Future that resolves to the full path to the file.
+            A Future that resolves to the full path to the downloaded file. Call
+            ``.result()`` on the Future to block until the download completes and
+            retrieve the file path.
+
+        Example:
+            >>> future = harmony_client.download(url, directory='/tmp', overwrite=True)
+            >>> filename = future.result()  # blocks until download completes
         """
         if url.endswith('zarr'):
             raise self.zarr_download_exception
@@ -975,10 +981,18 @@ class Client:
                      overwrite: bool = False) -> Generator[Future, None, None]:
         """Using a job_id, fetches all the data files from a finished job.
 
-        After this method is able to contact Harmony and query a finished job, it will
-        immediately return with a list of python concurrent.Futures corresponding to each of the
-        files to be downloaded. Call the result() method to block until the downloading of that
-        file is complete. When finished, the Future will return the filename.
+        This method is a **generator** that yields ``concurrent.futures.Future`` objects,
+        one per file to be downloaded. The downloads are submitted to a thread-pool
+        executor lazily as the generator is consumed.
+
+        .. warning::
+            Calling ``download_all()`` without consuming the generator (e.g. via
+            ``list()`` or a ``for`` loop) will **not** download any files. The
+            generator must be iterated for downloads to be submitted.
+
+        Call the ``result()`` method on each Future to block until that file's
+        download is complete. When finished, the Future will return the filename
+        (with path).
 
         Files are downloaded by an executor backed by a thread pool. Number of threads in the
         thread pool can be specified with the environment variable NUM_REQUESTS_WORKERS.
@@ -998,9 +1012,18 @@ class Client:
             downloaded file. Defaults to False. If you're seeing malformed data or truncated
             files from incomplete downloads, set overwrite to True.
 
-        Returns:
-            A list of Futures, each of which will return the filename (with path) for each
-            result.
+        Yields:
+            Future: A ``concurrent.futures.Future`` for each file being downloaded.
+            Each Future resolves to the filename (with path) of the downloaded file.
+
+        Example:
+            >>> # Download all files and wait for each to finish
+            >>> futures = harmony_client.download_all(job_id, directory='/tmp')
+            >>> file_names = [f.result() for f in futures]
+
+            >>> # Or collect the generator into a list first
+            >>> futures = list(harmony_client.download_all(job_id))
+            >>> file_names = [f.result() for f in futures]
         """
         if isinstance(job_id_or_result_json, str):
             try:

--- a/harmony/client.py
+++ b/harmony/client.py
@@ -967,7 +967,7 @@ class Client:
             retrieve the file path.
 
         Example:
-            >>> future = harmony_client.download(url, directory='/tmp', overwrite=True)
+            >>> future = client.download(url, directory='/tmp', overwrite=True)
             >>> filename = future.result()  # blocks until download completes
         """
         if url.endswith('zarr'):
@@ -1005,7 +1005,8 @@ class Client:
         Will wait for an unfinished job to finish before downloading.
 
         Args:
-            job_id: UUID string for the job you wish to interrogate.
+            job_id_or_result_json: UUID string for the job, or a result-json dict,
+            for the job whose files you wish to download.
             directory: Optional. If specified, saves files there. Saves files to the current
             working directory by default.
             overwrite: If True, will overwrite a local file that shares a filename with the
@@ -1017,7 +1018,7 @@ class Client:
             Each Future resolves to the filename (with path) of the downloaded file.
 
         Example:
-            >>> # Consume the generator to submit downloads, then wait for completion
+            >>> # Consume the generator to submit all downloads, then wait for completion
             >>> futures = list(client.download_all(job_id, directory='/tmp'))
             >>> file_names = [f.result() for f in futures]
         """


### PR DESCRIPTION
## Summary

Fixes #140

`download_all()` is typed as `Generator[Future, None, None]` but its docstring, the docs landing page, and several example notebooks all describe it as returning "a list of Futures". Users calling `download_all()` without consuming the generator get no files — the exact confusion reported here.

## Changes

- **`harmony/client.py`** — `download_all()`: rewritten docstring to describe generator behavior, added warning that downloads are lazy, changed `Returns:` → `Yields:`, added usage example. `download()`: added usage example showing `.result()`.
- **`docs/index.rst`** — Fixed quick-start example to consume the generator instead of calling `download_all()` without iterating.
- **`examples/basic.ipynb`** — Clarified that `download_all()` returns a generator, added note about lazy iteration.
- **`examples/intro_tutorial.ipynb`** — Same generator clarification.
- **`examples/job_results.ipynb`** — Fixed comment from "returns immediately with a list" to "is a generator that yields Future objects".

## Review feedback addressed

Copilot review comments addressed in the latest commit:
- Use `client` (not `harmony_client`) in docstring examples for module consistency
- Align `Args:` with the actual `job_id_or_result_json: Union[str, dict]` signature
- Example uses `list()` to consume the generator before waiting on futures (concurrent downloads)

No code changes — docs only.