### PR TITLE
docs: clarify download_all() is a generator, not a list

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,7 @@ Harmony-Py is a work-in-progress, is not feature complete, and should only be us
 
     >>> job_id = harmony_client.submit(request)
 
-    >>> harmony_client.download_all(job_id)
+    >>> filenames = [f.result() for f in harmony_client.download_all(job_id)]
 
 -------------------
 

--- a/examples/basic.ipynb
+++ b/examples/basic.ipynb
@@ -145,11 +145,11 @@
    "id": "threatened-complement",
    "metadata": {},
    "source": [
-    "There are a number of options available for downloading results. We'll start with the 'download_all()' method which uses a multithreaded downloader and quickly returns with a \"future\" (specifically a python conccurrent.futures future).\n",
+    "There are a number of options available for downloading results. We'll start with the 'download_all()' method which uses a multithreaded downloader and returns a **generator** of futures (specifically python concurrent.futures objects).\n",
     "\n",
-    "If you're unfamiliar with futures, at their most basic level they represent an eventual value. In our case, once a file is downloaded its future will contain the name of the local file. We can then hand the name off to other functions which open files based on their name to perform further operations. Work performed on behalf of each future takes place in a \"thread pool\" created for each Client instantiation.\n",
+    "If you're unfamiliar with futures, at their most basic level they represent an eventual value. In our case, once a file is downloaded its future will contain the name of the local file. We can then hand the name off to other functions which open files based on the filename.\n",
     "\n",
-    "To extract the eventual value of a future, call its 'result()' method. By using futures we can process downloaded files as soon as they're ready while the rest of the files are still downloading in the background. Because of how we're working with the futures, the order of our results are maintained even though the files will likely be downloaded out of order."
+    "**Important:** Because `download_all()` is a generator, downloads only begin when you iterate it. If you call `download_all()` but never iterate the result, no files will be downloaded. The simplest pattern is to use a list comprehension: `[f.result() for f in harmony_client.download_all(job_id)]`.\n"
    ]
   },
   {

--- a/examples/intro_tutorial.ipynb
+++ b/examples/intro_tutorial.ipynb
@@ -180,7 +180,7 @@
     "\n",
     "Other advanced parameters that may be of interest. Note that many reformatting or advanced projection options may not be available for your requested dataset. See the [documentation](https://harmony-py.readthedocs.io/en/latest/) for details on how to construct these parameters.\n",
     "\n",
-    "* `crs`: Reproject the output coverage to the given CRS. Recognizes CRS types that can be inferred by gdal, including EPSG codes, Proj4 strings, and OGC URLs (http://www.opengis.net/def/crs/…)\n",
+    "* `crs`: Reproject the output coverage to the given CRS. Recognizes CRS types that can be inferred by gdal, including EPSG codes, Proj4 strings, and OGC URLs (http://www.opengis.net/def/crs/\u2026)\n",
     "* `interpolation`: specify the interpolation method used during reprojection and scaling\n",
     "* `scale_extent`: scale the resulting coverage either among one axis to a given extent\n",
     "* `scale_size`: scale the resulting coverage either among one axis to a given size\n",
@@ -374,9 +374,9 @@
    "id": "1a46cae7",
    "metadata": {},
    "source": [
-    "The next code block utilizes `download_all()` to download all data output file URLs. This is a non-blocking step during the download itself, but this line will block subsequent code while waiting for the job to finish processing. You can optionally specify a directory and specify whether to overwrite existing files as shown below.\n",
+    "The next code block utilizes `download_all()` to download all data output file URLs. This call blocks while waiting for the job to finish processing, then returns a **generator** of future objects. You can optionally specify a directory and specify whether to overwrite existing files as shown below.\n",
     "\n",
-    "You may call `result()` on future objects (those that are awaiting processing) to realize them. A call to `result()` blocks until that particular future object finishes downloading. Other future objects will download in the background, in parallel. When downloading is complete, the future objects will return the file path string of the file that was just downloaded. This file path can then be fed into other libraries that may read the data files and perform other operations."
+    "**Important:** `download_all()` is a generator, meaning downloads only begin when you iterate it. If you assign the result to a variable but never iterate it, no files will be downloaded. You may call `result()` on each future object to block until that particular file finishes downloading. Other future objects will download in the background, in parallel. When downloading is complete, each future returns the file path string of the downloaded file, which can then be fed into other libraries that read the data files.\n"
    ]
   },
   {

--- a/examples/job_results.ipynb
+++ b/examples/job_results.ipynb
@@ -100,12 +100,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# 'download_all()' downloads all data urls and returns immediately with a list of concurrent.futures.\n",
+    "# 'download_all()' is a generator that yields concurrent.futures.Future objects, one per file.\n",
+    "# Downloads are lazy: they only begin when you iterate the generator.\n",
     "# Optionally shows progress bar for processing only.\n",
-    "# Non-blocking during download but blocking while waitinig for job processing to finish.\n",
-    "# Call 'result()' on future objects to realize them. A call to 'result()' blocks until that particular future finishes downloading. Other futures will download in the background, in parallel, up to the number of workers assigned to the thread pool (thread pool not publicly available).\n",
-    "# Downloading on any unfinished futures can be cancelled early.\n",
-    "# When downloading is complete the futures will return the file path string of the file that was just downloaded. This file path can then be fed into other libraries that may read the data files and perform other operations.\n",
+    "# Non-blocking during download but blocking while waiting for job processing to finish.\n",
+    "# Call 'result()' on each future to block until that file finishes downloading. Other futures\n",
+    "# will download in the background, in parallel, up to the number of workers in the thread pool.\n",
+    "# When complete, each future returns the file path string of the downloaded file.\n",
     "futures = harmony_client.download_all(job_id)\n",
     "file_names = [f.result() for f in futures]"
    ]

--- a/harmony/client.py
+++ b/harmony/client.py
@@ -951,7 +951,13 @@ class Client:
         return data['status'], data['message']
 
     def download(self, url: str, directory: str = '', overwrite: bool = False) -> Future:
-        """Downloads data and saves it to a file asynchronously.
+        """Downloads a single file asynchronously.
+
+        Returns a :class:`~concurrent.futures.Future` that resolves to the full path of the
+        downloaded file. The download happens in a background thread; call ``result()`` on the
+        returned Future to block until the download is complete::
+
+            file_name = harmony_client.download(url, directory='/tmp', overwrite=True).result()
 
         Args:
             url: The location (URL) of the file to be downloaded
@@ -962,7 +968,7 @@ class Client:
             files from incomplete downloads, set overwrite to True.
 
         Returns:
-            A Future that resolves to the full path to the file.
+            A :class:`~concurrent.futures.Future` that resolves to the full path to the file.
         """
         if url.endswith('zarr'):
             raise self.zarr_download_exception
@@ -975,10 +981,20 @@ class Client:
                      overwrite: bool = False) -> Generator[Future, None, None]:
         """Using a job_id, fetches all the data files from a finished job.
 
-        After this method is able to contact Harmony and query a finished job, it will
-        immediately return with a list of python concurrent.Futures corresponding to each of the
-        files to be downloaded. Call the result() method to block until the downloading of that
-        file is complete. When finished, the Future will return the filename.
+        This method is a **generator** that yields :class:`~concurrent.futures.Future` objects,
+        one per file to be downloaded. Downloads are lazy: they only begin when the generator
+        is iterated (e.g. with a ``for`` loop or a list comprehension). If you call this method
+        but never iterate the result, **no files will be downloaded**.
+
+        To trigger downloads and wait for all files to finish, consume the generator and call
+        ``result()`` on each Future::
+
+            futures = harmony_client.download_all(job_id, directory='/tmp', overwrite=True)
+            filenames = [f.result() for f in futures]
+
+        Each ``Future`` resolves to the full path of the downloaded file. Call ``result()`` to
+        block until that file finishes downloading; other files continue downloading in
+        parallel in the background.
 
         Files are downloaded by an executor backed by a thread pool. Number of threads in the
         thread pool can be specified with the environment variable NUM_REQUESTS_WORKERS.
@@ -998,9 +1014,9 @@ class Client:
             downloaded file. Defaults to False. If you're seeing malformed data or truncated
             files from incomplete downloads, set overwrite to True.
 
-        Returns:
-            A list of Futures, each of which will return the filename (with path) for each
-            result.
+        Yields:
+            A :class:`~concurrent.futures.Future` for each file, which will return the filename
+            (with path) when ``result()`` is called.
         """
         if isinstance(job_id_or_result_json, str):
             try:


### PR DESCRIPTION
## Summary

`download_all()` has been a generator since v0.2.0, but the docstrings, documentation, and example notebooks still describe it as returning a "list of Futures". This is a silent gotcha — new users call `download_all()` without iterating the result and receive no files, as reported in #140.

## Changes

- **`harmony/client.py`**: Rewrote `download_all()` docstring to explicitly state it is a **generator**, that downloads are lazy (only begin when the generator is iterated), and show the correct `[f.result() for f in ...]` usage pattern. Changed `Returns:` to `Yields:`. Also improved `download()` docstring with a usage example showing `.result()`.
- **`docs/index.rst`**: Fixed the quick-start example on the landing page to consume the generator (`filenames = [f.result() for f in harmony_client.download_all(job_id)]`) instead of calling `download_all()` without iterating.
- **`examples/basic.ipynb`**: Updated markdown to clarify `download_all()` returns a **generator** of futures, added a note about lazy iteration.
- **`examples/intro_tutorial.ipynb`**: Clarified that `download_all()` is a generator and downloads only begin on iteration.
- **`examples/job_results.ipynb`**: Fixed comment from "returns immediately with a list of concurrent.futures" to "is a generator that yields concurrent.futures.Future objects".

## The problem

From #140:

> In the following, downloading does not start until `result` is called.
> ```
> futures = harmony_client.download_all(job_id, directory="/tmp", overwrite=True)
> filelist = [f.result() for f in futures]
> ```
> Often, people do not include something comparable to that second line and receive no files.

The method signature already declares `-> Generator[Future, None, None]`, but every human-facing description said "list". This PR fixes the descriptions to match the actual behavior.

Fixes #140.

## Checklist

- [x] Documentation updated
- [x] No code changes (docs-only)
- [x] Examples use correct `[f.result() for f in ...]` pattern