### PR TITLE
HARMONY-2381:  Adds StepsRequest to access intermediate results

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -23,6 +23,8 @@ The classes in the ``harmony`` package that are used for crafting a request, sub
 
 .. autoclass:: harmony.JobsRequest
 
+.. autoclass:: harmony.StepsRequest
+
 .. autoclass:: harmony.Client
 
 When creating a request, the ``BBox`` and ``Collection`` classes are used to create a valid request.

--- a/examples/helper.py
+++ b/examples/helper.py
@@ -32,10 +32,10 @@ def install_project_and_dependencies(project_root, libs=None):
         # If libs are specified, install them
         if libs:
             libs_str = ','.join(libs)
-            os.system(f'{sys.executable} -m pip install -q .[{libs_str}]')
+            os.system(f'{sys.executable} -m pip install -q -e .[{libs_str}]')
 
         # Install the project itself
-        os.system(f'{sys.executable} -m pip install -q .')
+        os.system(f'{sys.executable} -m pip install -q -e .')
     finally:
         # Switch back to the original directory after installation
         os.chdir(original_dir)

--- a/examples/job_step_results.ipynb
+++ b/examples/job_step_results.ipynb
@@ -6,7 +6,8 @@
    "source": [
     "## Harmony Py Library\n",
     "### Job Steps Example\n",
-    "\n"
+    "\n",
+    "This notebook shows how to create a StepsRequest to interrogate intermediate results from a harmony service workflow. "
    ]
   },
   {

--- a/examples/job_step_results.ipynb
+++ b/examples/job_step_results.ipynb
@@ -1,0 +1,354 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Harmony Py Library\n",
+    "### Job Steps Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('127.0.0.1', 5678)"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import debugpy; debugpy.listen(5678)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import helper\n",
+    "helper.install_project_and_dependencies('..')\n",
+    "\n",
+    "import concurrent.futures\n",
+    "import os\n",
+    "import json\n",
+    "from harmony import BBox, Client, Collection, Request, Environment, StepsRequest\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "harmony_client = Client(env=Environment.UAT)  # assumes .netrc usage\n",
+    "\n",
+    "collection = Collection(id='C1234088182-EEDTEST')\n",
+    "request = Request(\n",
+    "    collection=collection,\n",
+    "    spatial=BBox(-165, 52, -140, 77)\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# submit an async request for processing and return the job_id\n",
+    "job_id = harmony_client.submit(request)\n",
+    "job_id\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_id = 'cdf52eaf-0211-4f20-84df-79120fe97ff9'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"jobID\": \"cdf52eaf-0211-4f20-84df-79120fe97ff9\",\n",
+      "  \"serviceName\": \"l2-subsetter-batchee-stitchee-concise\",\n",
+      "  \"status\": \"successful\",\n",
+      "  \"progress\": 100,\n",
+      "  \"message\": \"CMR query identified 132 granules, but the request has been limited to process only the first 80 granules because you requested 80 maxResults.\",\n",
+      "  \"username\": \"matthewsavoie\",\n",
+      "  \"numInputGranules\": 80,\n",
+      "  \"request\": \"https://harmony.uat.earthdata.nasa.gov/C1254854453-LARC_CLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(-70%3A30)&subset=lon(-157.5%3A-10)&concatenate=true&maxResults=80&extend=true&serviceId=l2-subsetter-batchee-stitchee-concise\",\n",
+      "  \"steps\": [\n",
+      "    {\n",
+      "      \"serviceID\": \"nasa/batchee:1.5.2\",\n",
+      "      \"stepIndex\": 3,\n",
+      "      \"workItemCount\": 1,\n",
+      "      \"statuses\": {\n",
+      "        \"successful\": 1\n",
+      "      },\n",
+      "      \"workItems\": [\n",
+      "        {\n",
+      "          \"id\": 9681851,\n",
+      "          \"status\": \"successful\",\n",
+      "          \"retryCount\": 0,\n",
+      "          \"inputFiles\": [\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681821/TEMPO_NO2_L2_V01_20240123T143356Z_S004G03_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681822/TEMPO_NO2_L2_V01_20240123T144034Z_S004G04_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681823/TEMPO_NO2_L2_V01_20240123T144711Z_S004G05_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681824/TEMPO_NO2_L2_V01_20240123T145348Z_S004G06_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681825/TEMPO_NO2_L2_V01_20240123T150026Z_S004G07_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681826/TEMPO_NO2_L2_V01_20240123T150703Z_S004G08_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681827/TEMPO_NO2_L2_V01_20240123T151340Z_S004G09_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681828/TEMPO_NO2_L2_V01_20240123T152036Z_S005G01_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681829/TEMPO_NO2_L2_V01_20240123T152716Z_S005G02_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681830/TEMPO_NO2_L2_V01_20240123T153356Z_S005G03_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681831/TEMPO_NO2_L2_V01_20240123T154034Z_S005G04_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681832/TEMPO_NO2_L2_V01_20240123T154711Z_S005G05_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681833/TEMPO_NO2_L2_V01_20240123T155348Z_S005G06_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681834/TEMPO_NO2_L2_V01_20240123T160026Z_S005G07_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681835/TEMPO_NO2_L2_V01_20240123T160703Z_S005G08_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681836/TEMPO_NO2_L2_V01_20240123T161340Z_S005G09_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681837/TEMPO_NO2_L2_V01_20240123T162036Z_S006G01_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681838/TEMPO_NO2_L2_V01_20240123T162716Z_S006G02_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681839/TEMPO_NO2_L2_V01_20240123T163356Z_S006G03_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681840/TEMPO_NO2_L2_V01_20240123T164034Z_S006G04_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681841/TEMPO_NO2_L2_V01_20240123T164711Z_S006G05_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681842/TEMPO_NO2_L2_V01_20240123T165348Z_S006G06_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681843/TEMPO_NO2_L2_V01_20240123T170026Z_S006G07_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681844/TEMPO_NO2_L2_V01_20240123T170703Z_S006G08_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681845/TEMPO_NO2_L2_V01_20240123T171340Z_S006G09_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681846/TEMPO_NO2_L2_V01_20240123T172036Z_S007G01_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681847/TEMPO_NO2_L2_V01_20240123T172716Z_S007G02_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681848/TEMPO_NO2_L2_V01_20240123T173356Z_S007G03_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681849/TEMPO_NO2_L2_V01_20240123T174034Z_S007G04_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681850/TEMPO_NO2_L2_V01_20240123T174711Z_S007G05_subsetted.nc\"\n",
+      "          ],\n",
+      "          \"inputFilesPaging\": {\n",
+      "            \"currentPage\": 2,\n",
+      "            \"lastPage\": 2,\n",
+      "            \"total\": 80,\n",
+      "            \"links\": [\n",
+      "              {\n",
+      "                \"title\": \"The first page (1 of 2)\",\n",
+      "                \"href\": \"https://harmony.uat.earthdata.nasa.gov/jobs/cdf52eaf-0211-4f20-84df-79120fe97ff9/steps?workitem=9681851%2C9681852&limit=5&resolvefiles=true&step2page=3&workitem9681851inputpage=1&wilimit=50\",\n",
+      "                \"rel\": \"first\",\n",
+      "                \"type\": \"application/json\"\n",
+      "              },\n",
+      "              {\n",
+      "                \"title\": \"The previous page (1 of 2)\",\n",
+      "                \"href\": \"https://harmony.uat.earthdata.nasa.gov/jobs/cdf52eaf-0211-4f20-84df-79120fe97ff9/steps?workitem=9681851%2C9681852&limit=5&resolvefiles=true&step2page=3&workitem9681851inputpage=1&wilimit=50\",\n",
+      "                \"rel\": \"prev\",\n",
+      "                \"type\": \"application/json\"\n",
+      "              },\n",
+      "              {\n",
+      "                \"title\": \"The current page (2 of 2)\",\n",
+      "                \"href\": \"https://harmony.uat.earthdata.nasa.gov/jobs/cdf52eaf-0211-4f20-84df-79120fe97ff9/steps?workitem=9681851%2C9681852&limit=5&resolvefiles=true&step2page=3&workitem9681851inputpage=2&wilimit=50\",\n",
+      "                \"rel\": \"self\",\n",
+      "                \"type\": \"application/json\"\n",
+      "              }\n",
+      "            ]\n",
+      "          },\n",
+      "          \"outputFiles\": [\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681771/TEMPO_NO2_L2_V01_20231206T125918Z_S002G01_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681772/TEMPO_NO2_L2_V01_20231206T130558Z_S002G02_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681773/TEMPO_NO2_L2_V01_20231206T131235Z_S002G03_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681774/TEMPO_NO2_L2_V01_20231206T131913Z_S002G04_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681775/TEMPO_NO2_L2_V01_20231206T132550Z_S002G05_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681776/TEMPO_NO2_L2_V01_20231206T133227Z_S002G06_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681777/TEMPO_NO2_L2_V01_20231206T133923Z_S003G01_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681778/TEMPO_NO2_L2_V01_20231206T134603Z_S003G02_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681779/TEMPO_NO2_L2_V01_20231206T135240Z_S003G03_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681780/TEMPO_NO2_L2_V01_20231206T135918Z_S003G04_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681781/TEMPO_NO2_L2_V01_20231206T140555Z_S003G05_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681782/TEMPO_NO2_L2_V01_20231206T141232Z_S003G06_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681783/TEMPO_NO2_L2_V01_20231206T141928Z_S004G01_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681784/TEMPO_NO2_L2_V01_20231206T142608Z_S004G02_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681785/TEMPO_NO2_L2_V01_20231206T143245Z_S004G03_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681786/TEMPO_NO2_L2_V01_20231206T143923Z_S004G04_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681787/TEMPO_NO2_L2_V01_20231206T144600Z_S004G05_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681788/TEMPO_NO2_L2_V01_20231206T145237Z_S004G06_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681789/TEMPO_NO2_L2_V01_20231206T145933Z_S005G01_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681790/TEMPO_NO2_L2_V01_20231206T150613Z_S005G02_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681791/TEMPO_NO2_L2_V01_20231206T151253Z_S005G03_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681792/TEMPO_NO2_L2_V01_20231206T151931Z_S005G04_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681793/TEMPO_NO2_L2_V01_20231206T152608Z_S005G05_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681794/TEMPO_NO2_L2_V01_20231206T153245Z_S005G06_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681795/TEMPO_NO2_L2_V01_20231206T153923Z_S005G07_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681796/TEMPO_NO2_L2_V01_20231206T154600Z_S005G08_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681797/TEMPO_NO2_L2_V01_20231206T155237Z_S005G09_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681798/TEMPO_NO2_L2_V01_20231206T155933Z_S006G01_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681799/TEMPO_NO2_L2_V01_20231206T160613Z_S006G02_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681800/TEMPO_NO2_L2_V01_20231206T161253Z_S006G03_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681801/TEMPO_NO2_L2_V01_20231206T161931Z_S006G04_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681802/TEMPO_NO2_L2_V01_20231206T162608Z_S006G05_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681803/TEMPO_NO2_L2_V01_20231206T163245Z_S006G06_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681804/TEMPO_NO2_L2_V01_20231206T163923Z_S006G07_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681805/TEMPO_NO2_L2_V01_20231206T164600Z_S006G08_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681806/TEMPO_NO2_L2_V01_20231206T165237Z_S006G09_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681807/TEMPO_NO2_L2_V01_20240123T130026Z_S002G01_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681808/TEMPO_NO2_L2_V01_20240123T130706Z_S002G02_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681809/TEMPO_NO2_L2_V01_20240123T131343Z_S002G03_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681810/TEMPO_NO2_L2_V01_20240123T132021Z_S002G04_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681811/TEMPO_NO2_L2_V01_20240123T132658Z_S002G05_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681812/TEMPO_NO2_L2_V01_20240123T133335Z_S002G06_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681813/TEMPO_NO2_L2_V01_20240123T134031Z_S003G01_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681814/TEMPO_NO2_L2_V01_20240123T134711Z_S003G02_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681815/TEMPO_NO2_L2_V01_20240123T135348Z_S003G03_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681816/TEMPO_NO2_L2_V01_20240123T140026Z_S003G04_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681817/TEMPO_NO2_L2_V01_20240123T140703Z_S003G05_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681818/TEMPO_NO2_L2_V01_20240123T141340Z_S003G06_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681819/TEMPO_NO2_L2_V01_20240123T142036Z_S004G01_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681820/TEMPO_NO2_L2_V01_20240123T142716Z_S004G02_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681821/TEMPO_NO2_L2_V01_20240123T143356Z_S004G03_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681822/TEMPO_NO2_L2_V01_20240123T144034Z_S004G04_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681823/TEMPO_NO2_L2_V01_20240123T144711Z_S004G05_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681824/TEMPO_NO2_L2_V01_20240123T145348Z_S004G06_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681825/TEMPO_NO2_L2_V01_20240123T150026Z_S004G07_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681826/TEMPO_NO2_L2_V01_20240123T150703Z_S004G08_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681827/TEMPO_NO2_L2_V01_20240123T151340Z_S004G09_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681828/TEMPO_NO2_L2_V01_20240123T152036Z_S005G01_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681829/TEMPO_NO2_L2_V01_20240123T152716Z_S005G02_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681830/TEMPO_NO2_L2_V01_20240123T153356Z_S005G03_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681831/TEMPO_NO2_L2_V01_20240123T154034Z_S005G04_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681832/TEMPO_NO2_L2_V01_20240123T154711Z_S005G05_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681833/TEMPO_NO2_L2_V01_20240123T155348Z_S005G06_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681834/TEMPO_NO2_L2_V01_20240123T160026Z_S005G07_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681835/TEMPO_NO2_L2_V01_20240123T160703Z_S005G08_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681836/TEMPO_NO2_L2_V01_20240123T161340Z_S005G09_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681837/TEMPO_NO2_L2_V01_20240123T162036Z_S006G01_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681838/TEMPO_NO2_L2_V01_20240123T162716Z_S006G02_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681839/TEMPO_NO2_L2_V01_20240123T163356Z_S006G03_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681840/TEMPO_NO2_L2_V01_20240123T164034Z_S006G04_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681841/TEMPO_NO2_L2_V01_20240123T164711Z_S006G05_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681842/TEMPO_NO2_L2_V01_20240123T165348Z_S006G06_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681843/TEMPO_NO2_L2_V01_20240123T170026Z_S006G07_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681844/TEMPO_NO2_L2_V01_20240123T170703Z_S006G08_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681845/TEMPO_NO2_L2_V01_20240123T171340Z_S006G09_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681846/TEMPO_NO2_L2_V01_20240123T172036Z_S007G01_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681847/TEMPO_NO2_L2_V01_20240123T172716Z_S007G02_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681848/TEMPO_NO2_L2_V01_20240123T173356Z_S007G03_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681849/TEMPO_NO2_L2_V01_20240123T174034Z_S007G04_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681850/TEMPO_NO2_L2_V01_20240123T174711Z_S007G05_subsetted.nc\"\n",
+      "          ]\n",
+      "        }\n",
+      "      ]\n",
+      "    },\n",
+      "    {\n",
+      "      \"serviceID\": \"nasa/stitchee:1.9.0\",\n",
+      "      \"stepIndex\": 4,\n",
+      "      \"workItemCount\": 11,\n",
+      "      \"statuses\": {\n",
+      "        \"successful\": 11\n",
+      "      },\n",
+      "      \"workItems\": [\n",
+      "        {\n",
+      "          \"id\": 9681852,\n",
+      "          \"status\": \"successful\",\n",
+      "          \"retryCount\": 0,\n",
+      "          \"inputFiles\": [\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681771/TEMPO_NO2_L2_V01_20231206T125918Z_S002G01_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681772/TEMPO_NO2_L2_V01_20231206T130558Z_S002G02_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681773/TEMPO_NO2_L2_V01_20231206T131235Z_S002G03_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681774/TEMPO_NO2_L2_V01_20231206T131913Z_S002G04_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681775/TEMPO_NO2_L2_V01_20231206T132550Z_S002G05_subsetted.nc\",\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681776/TEMPO_NO2_L2_V01_20231206T133227Z_S002G06_subsetted.nc\"\n",
+      "          ],\n",
+      "          \"outputFiles\": [\n",
+      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681852/C1254854453-LARC_CLOUD_batch_of_6_starting_from_TEMPO_NO2_L2_V01_20231206T125918Z_S002G01_subsetted_stitched.nc4\"\n",
+      "          ]\n",
+      "        }\n",
+      "      ]\n",
+      "    }\n",
+      "  ]\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "step_request = StepsRequest(\n",
+    "    job_id=job_id, \n",
+    "    limit=5,\n",
+    "    step_pages={2: 3},\n",
+    "    work_item_input_pages={9681851: 2},\n",
+    "    work_item=[9681851, 9681852],\n",
+    "    resolve_files=True,\n",
+    "    \n",
+    ")\n",
+    "response = harmony_client.submit(step_request)\n",
+    "print(json.dumps(response, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'https://harmony.uat.earthdata.nasa.gov/jobs/cdf52eaf-0211-4f20-84df-79120fe97ff9/steps?workItem=9681851%2C9681852&limit=5&resolveFiles=true&step2page=3&workItem9681851inputPage=2'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "harmony_client.request_as_url(step_request)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.5"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "691e87652ceac3c5099314ecb0538ffe7a8fdf4c87c30f290964dc685c42c47b"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/job_step_results.ipynb
+++ b/examples/job_step_results.ipynb
@@ -49,14 +49,14 @@
     "job_id = harmony_client.submit(request)\n",
     "job_id\n",
     "\n",
-    "harmony_client.wait_for_processing(job_id)\n"
+    "harmony_client.wait_for_processing(job_id, show_progress=True)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Form a simple request to the steps endpoint"
+    "### Form a simple request to the steps endpoint"
    ]
   },
   {

--- a/examples/job_step_results.ipynb
+++ b/examples/job_step_results.ipynb
@@ -77,14 +77,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Show the input and output files for the smap-l2-gridder step.\n"
+    "## Show the input and output files for the smap-l2-gridder step.\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We need to find the work_item of the harmony-smap-l2-gridder step to filter the resolve files results."
+    "Find the work_item of the harmony-smap-l2-gridder step to filter the resolve files request."
    ]
   },
   {
@@ -105,7 +105,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Make the request to resolve the input and output files."
+    "### Make the request to resolve the input and output files."
    ]
   },
   {
@@ -124,10 +124,10 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Download the input and output files "
+    "### Download the input and output files "
    ]
   },
   {
@@ -137,7 +137,6 @@
    "outputs": [],
    "source": [
     "input_file = response[\"steps\"][0][\"workItems\"][0][\"inputFiles\"][0]\n",
-    "\n",
     "output_file = response[\"steps\"][0][\"workItems\"][0][\"outputFiles\"][0]"
    ]
   },
@@ -148,8 +147,42 @@
    "outputs": [],
    "source": [
     "!curl -n -L -o \"Soil_Moisture_Retrieval_Data_landcover_class_fraction_subsetted.h5\" \"{input_file}\"\n",
-    "\n",
     "!curl -n -L -o \"Soil_Moisture_Retrieval_Data_landcover_class_fraction_subsetted_regridded.nc\" \"{output_file}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Paginating steps and resolved files\n",
+    "\n",
+    "When a step has many `workItems`, or a `workItem` resolves to many input/output\n",
+    "files, the steps endpoint paginates. `StepsRequest` exposes the dynamically-named\n",
+    "page parameters as dictionaries keyed by the relevant index:\n",
+    "\n",
+    "- `step_pages={step_index: page}` &rarr; `step<step_index>page=<page>`\n",
+    "- `work_item_input_pages={work_item_id: page}` &rarr; `workItem<work_item_id>inputPage=<page>`\n",
+    "- `work_item_output_pages={work_item_id: page}` &rarr; `workItem<work_item_id>outputPage=<page>`\n",
+    "\n",
+    "Use `request_as_url` to see how the dictionaries translate into query parameters\n",
+    "without submitting the request, since it is invalid for our test case."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "paged_request = StepsRequest(\n",
+    "    job_id=job_id,\n",
+    "    work_item=[workitem_id],\n",
+    "    resolve_files=True,\n",
+    "    step_pages={2: 3},\n",
+    "    work_item_input_pages={workitem_id: 2},\n",
+    "    work_item_output_pages={workitem_id: 4},\n",
+    ")\n",
+    "print(harmony_client.request_as_url(paged_request))"
    ]
   }
  ],

--- a/examples/job_step_results.ipynb
+++ b/examples/job_step_results.ipynb
@@ -5,58 +5,38 @@
    "metadata": {},
    "source": [
     "## Harmony Py Library\n",
-    "### Job Steps Example"
+    "### Job Steps Example\n",
+    "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "('127.0.0.1', 5678)"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "import debugpy; debugpy.listen(5678)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sys\n",
-    "import helper\n",
-    "helper.install_project_and_dependencies('..')\n",
-    "\n",
-    "import concurrent.futures\n",
-    "import os\n",
     "import json\n",
-    "from harmony import BBox, Client, Collection, Request, Environment, StepsRequest\n"
+    "from harmony import BBox, Client, Collection, Request, Environment, StepsRequest\n",
+    "\n",
+    "import helper\n",
+    "helper.install_project_and_dependencies('..')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "harmony_client = Client(env=Environment.UAT)  # assumes .netrc usage\n",
-    "\n",
-    "collection = Collection(id='C1234088182-EEDTEST')\n",
     "request = Request(\n",
-    "    collection=collection,\n",
-    "    spatial=BBox(-165, 52, -140, 77)\n",
-    ")\n"
+    "    collection=Collection(id='C1268429309-EEDTEST'),\n",
+    "    granule_id=['G1281797307-EEDTEST'],\n",
+    "    format='image/tiff',\n",
+    "    variables=['Soil_Moisture_Retrieval_Data/landcover_class_fraction'],\n",
+    "    labels=['harmony-py-steps-example'],\n",
+    ")\n",
+    "\n"
    ]
   },
   {
@@ -67,254 +47,16 @@
    "source": [
     "# submit an async request for processing and return the job_id\n",
     "job_id = harmony_client.submit(request)\n",
-    "job_id\n"
+    "job_id\n",
+    "\n",
+    "harmony_client.wait_for_processing(job_id)\n"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 3,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "job_id = 'cdf52eaf-0211-4f20-84df-79120fe97ff9'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{\n",
-      "  \"jobID\": \"cdf52eaf-0211-4f20-84df-79120fe97ff9\",\n",
-      "  \"serviceName\": \"l2-subsetter-batchee-stitchee-concise\",\n",
-      "  \"status\": \"successful\",\n",
-      "  \"progress\": 100,\n",
-      "  \"message\": \"CMR query identified 132 granules, but the request has been limited to process only the first 80 granules because you requested 80 maxResults.\",\n",
-      "  \"username\": \"matthewsavoie\",\n",
-      "  \"numInputGranules\": 80,\n",
-      "  \"request\": \"https://harmony.uat.earthdata.nasa.gov/C1254854453-LARC_CLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(-70%3A30)&subset=lon(-157.5%3A-10)&concatenate=true&maxResults=80&extend=true&serviceId=l2-subsetter-batchee-stitchee-concise\",\n",
-      "  \"steps\": [\n",
-      "    {\n",
-      "      \"serviceID\": \"nasa/batchee:1.5.2\",\n",
-      "      \"stepIndex\": 3,\n",
-      "      \"workItemCount\": 1,\n",
-      "      \"statuses\": {\n",
-      "        \"successful\": 1\n",
-      "      },\n",
-      "      \"workItems\": [\n",
-      "        {\n",
-      "          \"id\": 9681851,\n",
-      "          \"status\": \"successful\",\n",
-      "          \"retryCount\": 0,\n",
-      "          \"inputFiles\": [\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681821/TEMPO_NO2_L2_V01_20240123T143356Z_S004G03_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681822/TEMPO_NO2_L2_V01_20240123T144034Z_S004G04_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681823/TEMPO_NO2_L2_V01_20240123T144711Z_S004G05_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681824/TEMPO_NO2_L2_V01_20240123T145348Z_S004G06_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681825/TEMPO_NO2_L2_V01_20240123T150026Z_S004G07_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681826/TEMPO_NO2_L2_V01_20240123T150703Z_S004G08_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681827/TEMPO_NO2_L2_V01_20240123T151340Z_S004G09_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681828/TEMPO_NO2_L2_V01_20240123T152036Z_S005G01_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681829/TEMPO_NO2_L2_V01_20240123T152716Z_S005G02_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681830/TEMPO_NO2_L2_V01_20240123T153356Z_S005G03_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681831/TEMPO_NO2_L2_V01_20240123T154034Z_S005G04_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681832/TEMPO_NO2_L2_V01_20240123T154711Z_S005G05_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681833/TEMPO_NO2_L2_V01_20240123T155348Z_S005G06_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681834/TEMPO_NO2_L2_V01_20240123T160026Z_S005G07_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681835/TEMPO_NO2_L2_V01_20240123T160703Z_S005G08_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681836/TEMPO_NO2_L2_V01_20240123T161340Z_S005G09_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681837/TEMPO_NO2_L2_V01_20240123T162036Z_S006G01_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681838/TEMPO_NO2_L2_V01_20240123T162716Z_S006G02_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681839/TEMPO_NO2_L2_V01_20240123T163356Z_S006G03_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681840/TEMPO_NO2_L2_V01_20240123T164034Z_S006G04_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681841/TEMPO_NO2_L2_V01_20240123T164711Z_S006G05_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681842/TEMPO_NO2_L2_V01_20240123T165348Z_S006G06_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681843/TEMPO_NO2_L2_V01_20240123T170026Z_S006G07_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681844/TEMPO_NO2_L2_V01_20240123T170703Z_S006G08_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681845/TEMPO_NO2_L2_V01_20240123T171340Z_S006G09_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681846/TEMPO_NO2_L2_V01_20240123T172036Z_S007G01_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681847/TEMPO_NO2_L2_V01_20240123T172716Z_S007G02_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681848/TEMPO_NO2_L2_V01_20240123T173356Z_S007G03_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681849/TEMPO_NO2_L2_V01_20240123T174034Z_S007G04_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681850/TEMPO_NO2_L2_V01_20240123T174711Z_S007G05_subsetted.nc\"\n",
-      "          ],\n",
-      "          \"inputFilesPaging\": {\n",
-      "            \"currentPage\": 2,\n",
-      "            \"lastPage\": 2,\n",
-      "            \"total\": 80,\n",
-      "            \"links\": [\n",
-      "              {\n",
-      "                \"title\": \"The first page (1 of 2)\",\n",
-      "                \"href\": \"https://harmony.uat.earthdata.nasa.gov/jobs/cdf52eaf-0211-4f20-84df-79120fe97ff9/steps?workitem=9681851%2C9681852&limit=5&resolvefiles=true&step2page=3&workitem9681851inputpage=1&wilimit=50\",\n",
-      "                \"rel\": \"first\",\n",
-      "                \"type\": \"application/json\"\n",
-      "              },\n",
-      "              {\n",
-      "                \"title\": \"The previous page (1 of 2)\",\n",
-      "                \"href\": \"https://harmony.uat.earthdata.nasa.gov/jobs/cdf52eaf-0211-4f20-84df-79120fe97ff9/steps?workitem=9681851%2C9681852&limit=5&resolvefiles=true&step2page=3&workitem9681851inputpage=1&wilimit=50\",\n",
-      "                \"rel\": \"prev\",\n",
-      "                \"type\": \"application/json\"\n",
-      "              },\n",
-      "              {\n",
-      "                \"title\": \"The current page (2 of 2)\",\n",
-      "                \"href\": \"https://harmony.uat.earthdata.nasa.gov/jobs/cdf52eaf-0211-4f20-84df-79120fe97ff9/steps?workitem=9681851%2C9681852&limit=5&resolvefiles=true&step2page=3&workitem9681851inputpage=2&wilimit=50\",\n",
-      "                \"rel\": \"self\",\n",
-      "                \"type\": \"application/json\"\n",
-      "              }\n",
-      "            ]\n",
-      "          },\n",
-      "          \"outputFiles\": [\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681771/TEMPO_NO2_L2_V01_20231206T125918Z_S002G01_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681772/TEMPO_NO2_L2_V01_20231206T130558Z_S002G02_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681773/TEMPO_NO2_L2_V01_20231206T131235Z_S002G03_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681774/TEMPO_NO2_L2_V01_20231206T131913Z_S002G04_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681775/TEMPO_NO2_L2_V01_20231206T132550Z_S002G05_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681776/TEMPO_NO2_L2_V01_20231206T133227Z_S002G06_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681777/TEMPO_NO2_L2_V01_20231206T133923Z_S003G01_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681778/TEMPO_NO2_L2_V01_20231206T134603Z_S003G02_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681779/TEMPO_NO2_L2_V01_20231206T135240Z_S003G03_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681780/TEMPO_NO2_L2_V01_20231206T135918Z_S003G04_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681781/TEMPO_NO2_L2_V01_20231206T140555Z_S003G05_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681782/TEMPO_NO2_L2_V01_20231206T141232Z_S003G06_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681783/TEMPO_NO2_L2_V01_20231206T141928Z_S004G01_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681784/TEMPO_NO2_L2_V01_20231206T142608Z_S004G02_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681785/TEMPO_NO2_L2_V01_20231206T143245Z_S004G03_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681786/TEMPO_NO2_L2_V01_20231206T143923Z_S004G04_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681787/TEMPO_NO2_L2_V01_20231206T144600Z_S004G05_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681788/TEMPO_NO2_L2_V01_20231206T145237Z_S004G06_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681789/TEMPO_NO2_L2_V01_20231206T145933Z_S005G01_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681790/TEMPO_NO2_L2_V01_20231206T150613Z_S005G02_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681791/TEMPO_NO2_L2_V01_20231206T151253Z_S005G03_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681792/TEMPO_NO2_L2_V01_20231206T151931Z_S005G04_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681793/TEMPO_NO2_L2_V01_20231206T152608Z_S005G05_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681794/TEMPO_NO2_L2_V01_20231206T153245Z_S005G06_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681795/TEMPO_NO2_L2_V01_20231206T153923Z_S005G07_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681796/TEMPO_NO2_L2_V01_20231206T154600Z_S005G08_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681797/TEMPO_NO2_L2_V01_20231206T155237Z_S005G09_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681798/TEMPO_NO2_L2_V01_20231206T155933Z_S006G01_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681799/TEMPO_NO2_L2_V01_20231206T160613Z_S006G02_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681800/TEMPO_NO2_L2_V01_20231206T161253Z_S006G03_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681801/TEMPO_NO2_L2_V01_20231206T161931Z_S006G04_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681802/TEMPO_NO2_L2_V01_20231206T162608Z_S006G05_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681803/TEMPO_NO2_L2_V01_20231206T163245Z_S006G06_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681804/TEMPO_NO2_L2_V01_20231206T163923Z_S006G07_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681805/TEMPO_NO2_L2_V01_20231206T164600Z_S006G08_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681806/TEMPO_NO2_L2_V01_20231206T165237Z_S006G09_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681807/TEMPO_NO2_L2_V01_20240123T130026Z_S002G01_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681808/TEMPO_NO2_L2_V01_20240123T130706Z_S002G02_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681809/TEMPO_NO2_L2_V01_20240123T131343Z_S002G03_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681810/TEMPO_NO2_L2_V01_20240123T132021Z_S002G04_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681811/TEMPO_NO2_L2_V01_20240123T132658Z_S002G05_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681812/TEMPO_NO2_L2_V01_20240123T133335Z_S002G06_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681813/TEMPO_NO2_L2_V01_20240123T134031Z_S003G01_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681814/TEMPO_NO2_L2_V01_20240123T134711Z_S003G02_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681815/TEMPO_NO2_L2_V01_20240123T135348Z_S003G03_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681816/TEMPO_NO2_L2_V01_20240123T140026Z_S003G04_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681817/TEMPO_NO2_L2_V01_20240123T140703Z_S003G05_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681818/TEMPO_NO2_L2_V01_20240123T141340Z_S003G06_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681819/TEMPO_NO2_L2_V01_20240123T142036Z_S004G01_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681820/TEMPO_NO2_L2_V01_20240123T142716Z_S004G02_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681821/TEMPO_NO2_L2_V01_20240123T143356Z_S004G03_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681822/TEMPO_NO2_L2_V01_20240123T144034Z_S004G04_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681823/TEMPO_NO2_L2_V01_20240123T144711Z_S004G05_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681824/TEMPO_NO2_L2_V01_20240123T145348Z_S004G06_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681825/TEMPO_NO2_L2_V01_20240123T150026Z_S004G07_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681826/TEMPO_NO2_L2_V01_20240123T150703Z_S004G08_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681827/TEMPO_NO2_L2_V01_20240123T151340Z_S004G09_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681828/TEMPO_NO2_L2_V01_20240123T152036Z_S005G01_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681829/TEMPO_NO2_L2_V01_20240123T152716Z_S005G02_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681830/TEMPO_NO2_L2_V01_20240123T153356Z_S005G03_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681831/TEMPO_NO2_L2_V01_20240123T154034Z_S005G04_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681832/TEMPO_NO2_L2_V01_20240123T154711Z_S005G05_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681833/TEMPO_NO2_L2_V01_20240123T155348Z_S005G06_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681834/TEMPO_NO2_L2_V01_20240123T160026Z_S005G07_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681835/TEMPO_NO2_L2_V01_20240123T160703Z_S005G08_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681836/TEMPO_NO2_L2_V01_20240123T161340Z_S005G09_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681837/TEMPO_NO2_L2_V01_20240123T162036Z_S006G01_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681838/TEMPO_NO2_L2_V01_20240123T162716Z_S006G02_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681839/TEMPO_NO2_L2_V01_20240123T163356Z_S006G03_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681840/TEMPO_NO2_L2_V01_20240123T164034Z_S006G04_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681841/TEMPO_NO2_L2_V01_20240123T164711Z_S006G05_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681842/TEMPO_NO2_L2_V01_20240123T165348Z_S006G06_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681843/TEMPO_NO2_L2_V01_20240123T170026Z_S006G07_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681844/TEMPO_NO2_L2_V01_20240123T170703Z_S006G08_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681845/TEMPO_NO2_L2_V01_20240123T171340Z_S006G09_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681846/TEMPO_NO2_L2_V01_20240123T172036Z_S007G01_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681847/TEMPO_NO2_L2_V01_20240123T172716Z_S007G02_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681848/TEMPO_NO2_L2_V01_20240123T173356Z_S007G03_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681849/TEMPO_NO2_L2_V01_20240123T174034Z_S007G04_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681850/TEMPO_NO2_L2_V01_20240123T174711Z_S007G05_subsetted.nc\"\n",
-      "          ]\n",
-      "        }\n",
-      "      ]\n",
-      "    },\n",
-      "    {\n",
-      "      \"serviceID\": \"nasa/stitchee:1.9.0\",\n",
-      "      \"stepIndex\": 4,\n",
-      "      \"workItemCount\": 11,\n",
-      "      \"statuses\": {\n",
-      "        \"successful\": 11\n",
-      "      },\n",
-      "      \"workItems\": [\n",
-      "        {\n",
-      "          \"id\": 9681852,\n",
-      "          \"status\": \"successful\",\n",
-      "          \"retryCount\": 0,\n",
-      "          \"inputFiles\": [\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681771/TEMPO_NO2_L2_V01_20231206T125918Z_S002G01_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681772/TEMPO_NO2_L2_V01_20231206T130558Z_S002G02_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681773/TEMPO_NO2_L2_V01_20231206T131235Z_S002G03_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681774/TEMPO_NO2_L2_V01_20231206T131913Z_S002G04_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681775/TEMPO_NO2_L2_V01_20231206T132550Z_S002G05_subsetted.nc\",\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681776/TEMPO_NO2_L2_V01_20231206T133227Z_S002G06_subsetted.nc\"\n",
-      "          ],\n",
-      "          \"outputFiles\": [\n",
-      "            \"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-artifacts-uat/public/l2-subsetter-batchee-stitchee-concise/25de0f54-666f-4149-a603-82fe7e39fd5a/9681852/C1254854453-LARC_CLOUD_batch_of_6_starting_from_TEMPO_NO2_L2_V01_20231206T125918Z_S002G01_subsetted_stitched.nc4\"\n",
-      "          ]\n",
-      "        }\n",
-      "      ]\n",
-      "    }\n",
-      "  ]\n",
-      "}\n"
-     ]
-    }
-   ],
-   "source": [
-    "step_request = StepsRequest(\n",
-    "    job_id=job_id, \n",
-    "    limit=5,\n",
-    "    step_pages={2: 3},\n",
-    "    work_item_input_pages={9681851: 2},\n",
-    "    work_item=[9681851, 9681852],\n",
-    "    resolve_files=True,\n",
-    "    \n",
-    ")\n",
-    "response = harmony_client.submit(step_request)\n",
-    "print(json.dumps(response, indent=2))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'https://harmony.uat.earthdata.nasa.gov/jobs/cdf52eaf-0211-4f20-84df-79120fe97ff9/steps?workItem=9681851%2C9681852&limit=5&resolveFiles=true&step2page=3&workItem9681851inputPage=2'"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "harmony_client.request_as_url(step_request)\n"
+    "Form a simple request to the steps endpoint"
    ]
   },
   {
@@ -322,7 +64,93 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "\n",
+    "step_request = StepsRequest(\n",
+    "    job_id=job_id, \n",
+    ")\n",
+    "response = harmony_client.submit(step_request)\n",
+    "print(json.dumps(response, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Show the input and output files for the smap-l2-gridder step.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We need to find the work_item of the harmony-smap-l2-gridder step to filter the resolve files results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "workitem_id = next(\n",
+    "    step[\"workItems\"][0][\"id\"]\n",
+    "    for step in response[\"steps\"]\n",
+    "    if \"smap-l2-gridder\" in step[\"serviceID\"]\n",
+    ")\n",
+    "workitem_id"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make the request to resolve the input and output files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "step_files_request = StepsRequest(\n",
+    "    job_id=job_id, \n",
+    "    work_item=[workitem_id],\n",
+    "    resolve_files=True, \n",
+    ")\n",
+    "response = harmony_client.submit(step_files_request)\n",
+    "print(json.dumps(response, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "Download the input and output files "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_file = response[\"steps\"][0][\"workItems\"][0][\"inputFiles\"][0]\n",
+    "\n",
+    "output_file = response[\"steps\"][0][\"workItems\"][0][\"outputFiles\"][0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!curl -n -L -o \"Soil_Moisture_Retrieval_Data_landcover_class_fraction_subsetted.h5\" \"{input_file}\"\n",
+    "\n",
+    "!curl -n -L -o \"Soil_Moisture_Retrieval_Data_landcover_class_fraction_subsetted_regridded.nc\" \"{output_file}\""
+   ]
   }
  ],
  "metadata": {

--- a/harmony/__init__.py
+++ b/harmony/__init__.py
@@ -3,6 +3,6 @@ __version__ = "1.4.0"
 
 from harmony.config import Environment
 from harmony.request import BBox, WKT, Collection, LinkType, Dimension, Request, \
-    CapabilitiesRequest, AddLabelsRequest, DeleteLabelsRequest, JobsRequest
+    CapabilitiesRequest, AddLabelsRequest, DeleteLabelsRequest, JobsRequest, StepsRequest
 from harmony.client import Client
 from harmony.util import s3_components

--- a/harmony/client.py
+++ b/harmony/client.py
@@ -94,6 +94,7 @@ class ProcessingFailedException(Exception):
 
 # Mapping of request types to their corresponding URL endpoints
 # Uses lambda functions to dynamically construct URLs based on the request type
+# and request.
 request_url_map = {
     CapabilitiesRequest: lambda self, request: f'{self.config.root_url}/capabilities',
     AddLabelsRequest: lambda self, request: f'{self.config.root_url}/labels',

--- a/harmony/client.py
+++ b/harmony/client.py
@@ -48,7 +48,7 @@ from harmony.auth import create_session, validate_auth
 from harmony.config import Config, Environment
 from harmony.request import Collection, BBox, WKT, LinkType, _shapefile_exts_to_mimes, \
     BaseRequest, OgcBaseRequest, CapabilitiesRequest, AddLabelsRequest, \
-    DeleteLabelsRequest, JobsRequest
+    DeleteLabelsRequest, JobsRequest, StepsRequest
 from harmony.util import get_json_from_response
 from harmony import __version__ as harmony_version
 
@@ -95,10 +95,11 @@ class ProcessingFailedException(Exception):
 # Mapping of request types to their corresponding URL endpoints
 # Uses lambda functions to dynamically construct URLs based on the request type
 request_url_map = {
-    CapabilitiesRequest: lambda self: f'{self.config.root_url}/capabilities',
-    AddLabelsRequest: lambda self: f'{self.config.root_url}/labels',
-    DeleteLabelsRequest: lambda self: f'{self.config.root_url}/labels',
-    JobsRequest: lambda self: f'{self.config.root_url}/jobs',
+    CapabilitiesRequest: lambda self, request: f'{self.config.root_url}/capabilities',
+    AddLabelsRequest: lambda self, request: f'{self.config.root_url}/labels',
+    DeleteLabelsRequest: lambda self, request: f'{self.config.root_url}/labels',
+    JobsRequest: lambda self, request: f'{self.config.root_url}/jobs',
+    StepsRequest: lambda self, request: f'{self.config.root_url}/jobs/{request.job_id}/steps',
 }
 
 
@@ -217,7 +218,7 @@ class Client:
                     f'/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset'
                 )
         else:
-            return request_url_map[type(request)](self)
+            return request_url_map[type(request)](self, request)
 
     def _status_url(self, job_id: str, link_type: LinkType = LinkType.https) -> str:
         """Constructs the URL for the Job that is used to get its status."""

--- a/harmony/request.py
+++ b/harmony/request.py
@@ -601,9 +601,9 @@ class JobsRequest(BaseRequest):
 
     def __init__(self,
                  *,
-                 page: int = None,
-                 limit: int = None,
-                 labels: List[str] = None,
+                 page: int | None = None,
+                 limit: int | None = None,
+                 labels: List[str] | None = None,
                  ):
         super().__init__()
         self.page = page
@@ -632,8 +632,11 @@ class StepsRequest(BaseRequest):
       wi_limit (int): page size when resolving files.
 
       *** TODO [MHS, 07/07/2026] Still need to handle dynamic pages. ***
-      step_pages (dict[int, int]): dict of [stepIndex, PageNumber] -> step<stepIndex>page=<PageNumber>
+      step_pages (dict[int, int]): dict of [stepIndex, PageNumber] -> step<step_index>page=<page_number>
+      step2page=2
 
+      work_item_inputs (dict[int, int]) -> workItem<wi_idx>inputpage=<page_number>
+      work_item_outputs (dict[int, int]) -> workItem<wi_idx>outputpage=<page_number>
 
 
      ?workitem=9681851&resolvefiles=true&workitem9681851inputpage=2&wilimit=50
@@ -641,8 +644,23 @@ class StepsRequest(BaseRequest):
      ?workitem=9681851&resolvefiles=true&workitem9681851inputpage=3&wilimit=10&workitem9681851outputpage=2
      ?resolvefiles=false&workitem9681851inputpage=3&wilimit=10&workitem9681851outputpage=2&step2page=2&limit=5
 
+
+
     """
-    def __init__(self, *, job_id, step=None, status=None, work_item=None, limit=None, resolve_files=False, wi_limit=None):
+    def __init__(
+        self,
+        *,
+        job_id: str,
+        step: int | None = None,
+        status: str | list[str] | None = None,
+        work_item: int | list[int] | None = None,
+        limit: int | None = None,
+        resolve_files: bool = False,
+        wi_limit: int | None = None,
+        step_pages: dict[int, int] = {},
+        work_item_input_pages: dict[int, int] = {},
+        work_item_output_pages: dict[int, int] = {},
+    ):
         super().__init__()
         self.job_id = job_id
         self.step = step
@@ -651,18 +669,40 @@ class StepsRequest(BaseRequest):
         self.limit = limit
         self.resolve_files = resolve_files
         self.wi_limit = wi_limit
+        self.step_pages = step_pages
+        self.work_item_input_pages = work_item_input_pages
+        self.work_item_output_pages = work_item_output_pages
+        print("here's a steps request")
 
         self.variable_name_to_query_param = {
-            "step": "step",
-            "status": "status",
-            "work_item": "workItem",
-            "limit": "limit",
-            "resolve_files": "resolveFiles",
-            "wi_limit": "wiLimit",
+            'step': 'step',
+            'status': 'status',
+            'work_item': 'workItem',
+            'limit': 'limit',
+            'resolve_files': 'resolveFiles',
+            'wi_limit': 'wiLimit',
         }
 
+    def parameter_values(self) -> list[tuple[str, Any]]:
+        """Turn calling arguments into correct queryParams for step endpoint.
 
+        The step endpoint has dynamically generated query params.
+        e.g. `step2page=3`, means the user wants the stepindex 2 page 3 of results.
+        We want to allow the user to specify these as
+        step_pages => dict[idx:str: pg_no:int]
+        step_pages= {'3': 1, '2': 2} -> '?step3page=1&step2page=2'
+        work_item_input_pages
+        work_item_output_pages
 
+        """
+        pvs = super().parameter_values()
+        for step_idx, pg_no in self.step_pages.items():
+            pvs.append(( f'step{step_idx}page', pg_no))
+        for wi_idx, pg_no in self.work_item_input_pages.items():
+            pvs.append(( f'workItem{wi_idx}inputPage', pg_no))
+        for wi_idx, pg_no in self.work_item_output_pages.items():
+            pvs.append(( f'workItem{wi_idx}outputPage', pg_no))
+        return pvs
 
 
 class LinkType(Enum):

--- a/harmony/request.py
+++ b/harmony/request.py
@@ -635,9 +635,9 @@ class StepsRequest(BaseRequest):
         step_pages (dict[int, int]): Page number to request for a step index,
             e.g. {2: 3} -> step2page=3
         work_item_input_pages (dict[int, int]): Page number to request for a workItem's
-            inputs, e.g. {9681851: 2} -> workItem9681851inputPage=2
+            inputs, e.g. {95: 2} -> workItem95inputPage=2
         work_item_output_pages (dict[int, int]): Page number to request for a workItem's
-            outputs, e.g. {9681851: 2} -> workItem9681851outputPage=2
+            outputs, e.g. {97: 2} -> workItem97outputPage=2
 
     Returns:
         StepsRequest: An instance of the steps request configured with the provided parameters.

--- a/harmony/request.py
+++ b/harmony/request.py
@@ -164,10 +164,7 @@ class BaseRequest:
     requests.
 
     Args:
-        collection: The CMR collection that should be queried
-
-    Returns:
-        A Harmony Request instance
+       http_method: The HTTP method to use for the request. Defaults to GET.
     """
 
     def __init__(self,
@@ -618,6 +615,54 @@ class JobsRequest(BaseRequest):
             'limit': 'limit',
             'labels': 'label',
         }
+
+class StepsRequest(BaseRequest):
+    """A harmony request to access a Jobs steps
+
+    See documentation for query parameters.
+    https://harmony.earthdata.nasa.gov/docs#inspecting-a-job's-steps-with-the-steps-api
+
+    Args:
+      job_id (int): The job to inspect.
+      step (list[int]): The job's step index to include.
+      status (list[str]): statuses to include.
+      work_item (list[int]): workItem values to include.
+      limit (int): number of workItems to include for each step.
+      resolve_files (bool): Whether to resolve the intermediate files or not. requires a workItem filter.
+      wi_limit (int): page size when resolving files.
+
+      *** TODO [MHS, 07/07/2026] Still need to handle dynamic pages. ***
+      step_pages (dict[int, int]): dict of [stepIndex, PageNumber] -> step<stepIndex>page=<PageNumber>
+
+
+
+     ?workitem=9681851&resolvefiles=true&workitem9681851inputpage=2&wilimit=50
+     ?workitem=9681851&resolvefiles=true&workitem9681851inputpage=2&wilimit=10
+     ?workitem=9681851&resolvefiles=true&workitem9681851inputpage=3&wilimit=10&workitem9681851outputpage=2
+     ?resolvefiles=false&workitem9681851inputpage=3&wilimit=10&workitem9681851outputpage=2&step2page=2&limit=5
+
+    """
+    def __init__(self, *, job_id, step=None, status=None, work_item=None, limit=None, resolve_files=False, wi_limit=None):
+        super().__init__()
+        self.job_id = job_id
+        self.step = step
+        self.status = status
+        self.work_item = work_item
+        self.limit = limit
+        self.resolve_files = resolve_files
+        self.wi_limit = wi_limit
+
+        self.variable_name_to_query_param = {
+            "step": "step",
+            "status": "status",
+            "work_item": "workItem",
+            "limit": "limit",
+            "resolve_files": "resolveFiles",
+            "wi_limit": "wiLimit",
+        }
+
+
+
 
 
 class LinkType(Enum):

--- a/harmony/request.py
+++ b/harmony/request.py
@@ -616,50 +616,46 @@ class JobsRequest(BaseRequest):
             'labels': 'label',
         }
 
+
 class StepsRequest(BaseRequest):
-    """A harmony request to access a Jobs steps
+    """A Harmony request to inspect a job's steps.
 
     See documentation for query parameters.
     https://harmony.earthdata.nasa.gov/docs#inspecting-a-job's-steps-with-the-steps-api
 
     Args:
-      job_id (int): The job to inspect.
-      step (list[int]): The job's step index to include.
-      status (list[str]): statuses to include.
-      work_item (list[int]): workItem values to include.
-      limit (int): number of workItems to include for each step.
-      resolve_files (bool): Whether to resolve the intermediate files or not. requires a workItem filter.
-      wi_limit (int): page size when resolving files.
+        job_id (str): The job to inspect.
+        step (int): The job's step index to include.
+        status (List[str]): Statuses to include.
+        work_item (List[int]): workItem values to include.
+        limit (int): The number of workItems to include for each step.
+        resolve_files (bool): Whether to resolve the intermediate files or not.
+            Requires a work_item filter.
+        wi_limit (int): Page size when resolving files.
+        step_pages (dict[int, int]): Page number to request for a step index,
+            e.g. {2: 3} -> step2page=3
+        work_item_input_pages (dict[int, int]): Page number to request for a workItem's
+            inputs, e.g. {9681851: 2} -> workItem9681851inputPage=2
+        work_item_output_pages (dict[int, int]): Page number to request for a workItem's
+            outputs, e.g. {9681851: 2} -> workItem9681851outputPage=2
 
-      *** TODO [MHS, 07/07/2026] Still need to handle dynamic pages. ***
-      step_pages (dict[int, int]): dict of [stepIndex, PageNumber] -> step<step_index>page=<page_number>
-      step2page=2
-
-      work_item_inputs (dict[int, int]) -> workItem<wi_idx>inputpage=<page_number>
-      work_item_outputs (dict[int, int]) -> workItem<wi_idx>outputpage=<page_number>
-
-
-     ?workitem=9681851&resolvefiles=true&workitem9681851inputpage=2&wilimit=50
-     ?workitem=9681851&resolvefiles=true&workitem9681851inputpage=2&wilimit=10
-     ?workitem=9681851&resolvefiles=true&workitem9681851inputpage=3&wilimit=10&workitem9681851outputpage=2
-     ?resolvefiles=false&workitem9681851inputpage=3&wilimit=10&workitem9681851outputpage=2&step2page=2&limit=5
-
-
-
+    Returns:
+        StepsRequest: An instance of the steps request configured with the provided parameters.
     """
+
     def __init__(
         self,
         *,
         job_id: str,
         step: int | None = None,
-        status: str | list[str] | None = None,
-        work_item: int | list[int] | None = None,
+        status: str | List[str] | None = None,
+        work_item: int | List[int] | None = None,
         limit: int | None = None,
-        resolve_files: bool = False,
+        resolve_files: bool | None = None,
         wi_limit: int | None = None,
-        step_pages: dict[int, int] = {},
-        work_item_input_pages: dict[int, int] = {},
-        work_item_output_pages: dict[int, int] = {},
+        step_pages: dict[int, int] | None = None,
+        work_item_input_pages: dict[int, int] | None = None,
+        work_item_output_pages: dict[int, int] | None = None,
     ):
         super().__init__()
         self.job_id = job_id
@@ -669,10 +665,9 @@ class StepsRequest(BaseRequest):
         self.limit = limit
         self.resolve_files = resolve_files
         self.wi_limit = wi_limit
-        self.step_pages = step_pages
-        self.work_item_input_pages = work_item_input_pages
-        self.work_item_output_pages = work_item_output_pages
-        print("here's a steps request")
+        self.step_pages = step_pages or {}
+        self.work_item_input_pages = work_item_input_pages or {}
+        self.work_item_output_pages = work_item_output_pages or {}
 
         self.variable_name_to_query_param = {
             'step': 'step',
@@ -683,7 +678,17 @@ class StepsRequest(BaseRequest):
             'wi_limit': 'wiLimit',
         }
 
-    def parameter_values(self) -> list[tuple[str, Any]]:
+    def error_messages(self) -> List[str]:
+        """A list of error messages, if any, for the request."""
+        error_msgs = []
+        if self.resolve_files and self.work_item is None:
+            error_msgs = [
+                'resolve_files requires a work_item filter for StepsRequest'
+            ]
+
+        return error_msgs
+
+    def parameter_values(self) -> List[Tuple[str, Any]]:
         """Turn calling arguments into correct queryParams for step endpoint.
 
         The step endpoint has dynamically generated query params.
@@ -697,11 +702,11 @@ class StepsRequest(BaseRequest):
         """
         pvs = super().parameter_values()
         for step_idx, pg_no in self.step_pages.items():
-            pvs.append(( f'step{step_idx}page', pg_no))
+            pvs.append((f'step{step_idx}page', pg_no))
         for wi_idx, pg_no in self.work_item_input_pages.items():
-            pvs.append(( f'workItem{wi_idx}inputPage', pg_no))
+            pvs.append((f'workItem{wi_idx}inputPage', pg_no))
         for wi_idx, pg_no in self.work_item_output_pages.items():
-            pvs.append(( f'workItem{wi_idx}outputPage', pg_no))
+            pvs.append((f'workItem{wi_idx}outputPage', pg_no))
         return pvs
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,3 +92,6 @@ exclude = ["contrib", "docs", "tests*"]
 [tool.flake8]
 max-line-length = 99
 ignore = ["F401", "W503"]
+
+[tool.ruff.format]
+quote-style = "single"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,7 +14,7 @@ from responses import registries
 
 from urllib3.util.retry import Retry
 from harmony.request import BBox, Collection, LinkType, Request, Dimension, CapabilitiesRequest, \
-    AddLabelsRequest, DeleteLabelsRequest, JobsRequest
+    AddLabelsRequest, DeleteLabelsRequest, JobsRequest, StepsRequest
 from harmony.client import Client, ProcessingFailedException, DEFAULT_JOB_LABEL
 from harmony.config import Environment
 
@@ -39,6 +39,9 @@ def expected_resume_url(job_id, link_type: LinkType = LinkType.https):
 
 def expected_cancel_url(job_id):
     return f'https://harmony.earthdata.nasa.gov/jobs/{job_id}/cancel'
+
+def expected_steps_url(job_id):
+    return f'https://harmony.earthdata.nasa.gov/jobs/{job_id}/steps'
 
 def parse_multipart_data(request):
     """Parses multipart/form-data request to extract fields as strings."""
@@ -1947,6 +1950,102 @@ def test_get_jobs():
     assert responses.calls[0].request.method == 'GET'
     assert responses.calls[0].request.url == expected_url
     assert result == expected_result
+
+
+@responses.activate
+def test_get_job_steps():
+    job_id = 'jobs-uuid'
+    request = StepsRequest(job_id=job_id)
+
+    # dummy result
+    expected_result = {"steps":[{"stepIndex":1,"status":"successful"}]}
+
+    responses.add(
+        responses.GET,
+        expected_steps_url(job_id),
+        status=200,
+        json=expected_result,
+    )
+
+    result = Client(should_validate_auth=False).submit(request)
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.method == 'GET'
+    assert responses.calls[0].request.url == expected_steps_url(job_id)
+    assert result == expected_result
+
+
+@responses.activate
+def test_get_job_steps_with_filters():
+    job_id = 'jobs-uuid'
+    request = StepsRequest(
+        job_id=job_id,
+        step=2,
+        status=['successful', 'running'],
+        work_item=[1, 2],
+        limit=5,
+        resolve_files=True,
+        wi_limit=10,
+    )
+
+    expected_url = (f'{expected_steps_url(job_id)}?step=2&status=successful&status=running'
+                    f'&workItem=1%2C2&limit=5&resolveFiles=true&wiLimit=10')
+    expected_result = {"steps":[{"stepIndex":2,"status":"running"}]}
+
+    responses.add(
+        responses.GET,
+        expected_url,
+        status=200,
+        json=expected_result,
+    )
+
+    result = Client(should_validate_auth=False).submit(request)
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.method == 'GET'
+    assert responses.calls[0].request.url == expected_url
+    assert result == expected_result
+
+
+@responses.activate
+def test_get_job_steps_with_dynamic_page_params():
+    job_id = 'jobs-uuid'
+    request = StepsRequest(
+        job_id=job_id,
+        step_pages={2: 3},
+        work_item_input_pages={985: 2},
+        work_item_output_pages={985: 4},
+    )
+
+    expected_url = (f'{expected_steps_url(job_id)}?step2page=3'
+                    f'&workItem985inputPage=2&workItem985outputPage=4')
+    expected_result = {"steps":[{"stepIndex":2,"status":"successful"}]}
+
+    responses.add(
+        responses.GET,
+        expected_url,
+        status=200,
+        json=expected_result,
+    )
+
+    result = Client(should_validate_auth=False).submit(request)
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.method == 'GET'
+    assert responses.calls[0].request.url == expected_url
+    assert result == expected_result
+
+
+@responses.activate
+def test_get_job_steps_resolve_files_without_work_item():
+    request = StepsRequest(job_id='jobs-uuid', resolve_files=True)
+
+    with pytest.raises(Exception) as e:
+        Client(should_validate_auth=False).submit(request)
+
+    assert str(e.value) == ('Cannot submit the request due to the following errors: '
+                            '[resolve_files requires a work_item filter for StepsRequest]')
+    assert len(responses.calls) == 0
 
 def test_client_environment_not_affected_by_env_var():
     os.environ['ENVIRONMENT'] = 'UAT'

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -4,7 +4,7 @@ from hypothesis import given, settings, strategies as st
 import pytest
 
 from harmony.request import BBox, WKT, Collection, OgcBaseRequest, Request, Dimension, \
-    CapabilitiesRequest, AddLabelsRequest, DeleteLabelsRequest, JobsRequest
+    CapabilitiesRequest, AddLabelsRequest, DeleteLabelsRequest, JobsRequest, StepsRequest
 
 
 def test_request_has_collection_with_id():
@@ -387,6 +387,65 @@ def test_valid_get_jobs_request_with_multiple_labels_in_string():
 def test_get_jobs_request_with_invalid_argument():
     with pytest.raises(TypeError, match=".*got an unexpected keyword argument 'page_num'"):
         JobsRequest(page_num=1)
+
+
+def test_valid_steps_request():
+    request = StepsRequest(job_id='jobs-uuid')
+    assert request.is_valid()
+
+
+def test_valid_steps_request_with_all_params():
+    request = StepsRequest(job_id='jobs-uuid',
+                           step=2,
+                           status=['running', 'successful'],
+                           work_item=[1, 2],
+                           limit=5,
+                           resolve_files=True,
+                           wi_limit=10,
+                           step_pages={2: 3},
+                           work_item_input_pages={1: 2},
+                           work_item_output_pages={1: 4})
+    assert request.is_valid()
+
+
+def test_steps_request_missing_job_id():
+    with pytest.raises(TypeError, match=".*missing 1 required keyword-only argument: 'job_id'"):
+        StepsRequest()
+
+
+def test_steps_request_with_invalid_argument():
+    with pytest.raises(TypeError, match=".*got an unexpected keyword argument 'jobid'"):
+        StepsRequest(jobid='jobs-uuid')
+
+
+def test_steps_request_resolve_files_without_work_item_filter():
+    request = StepsRequest(job_id='jobs-uuid', resolve_files=True)
+    messages = request.error_messages()
+
+    assert not request.is_valid()
+    assert 'resolve_files requires a work_item filter for StepsRequest' in messages
+
+
+def test_valid_steps_request_resolve_files_with_work_item():
+    request = StepsRequest(job_id='jobs-uuid', resolve_files=True, work_item=985)
+    assert request.is_valid()
+
+
+def test_steps_request_parameter_values_omits_unset():
+    request = StepsRequest(job_id='jobs-uuid', work_item=33)
+    assert request.parameter_values() == [('workItem', 33)]
+
+
+def test_steps_request_parameter_values_with_dynamic_pages():
+    request = StepsRequest(job_id='jobs-uuid',
+                           step_pages={2: 3},
+                           work_item_input_pages={985: 2},
+                           work_item_output_pages={985: 4})
+    parameter_values = request.parameter_values()
+
+    assert ('step2page', 3) in parameter_values
+    assert ('workItem985inputPage', 2) in parameter_values
+    assert ('workItem985outputPage', 4) in parameter_values
 
 def test_request_with_pixel_subset_false():
     request = Request(collection=Collection('foobar'), pixel_subset=False)


### PR DESCRIPTION
## Jira Issue ID

[HARMONY-2381](https://bugs.earthdata.nasa.gov/browse/HARMONY-2381)

## Description

Adds support for steps endpoint to harmony-py.

Creates a new StepsRequest from a BaseRequest and handles all of the steps query parameters.
The only pre-request error validation added is for the case of resolve_files requiring a work_item.


## Local Test Steps

Pull and test this version of harmony-py.

Create a local python virtual environment and install and test the branch.

```sh
> make install
> make test
> make lint
> make docs
```


Verify the docs show the new StepsRequest.
You can look at [read-the-docs for this PR](https://harmony-py--145.org.readthedocs.build/en/145/api.html#harmony.request.StepsRequest). 


Run through the new notebook
`examples/job_step_results.ipynb`

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [X] Documentation updated (if needed)
