### PR TITLE
Raise on an error response in _download_file

### DIFF
--- a/harmony/client.py
+++ b/harmony/client.py
@@ -928,6 +928,9 @@ class Client:
             }
             with getattr(session, method)(
                     new_url, data=data_dict, stream=True, headers=headers) as r:
+                # Without this an error response body (a 401 page, a Harmony
+                # error document) is written to disk and looks like data.
+                r.raise_for_status()
                 with open(filename, 'wb') as f:
                     shutil.copyfileobj(r.raw, f, length=chunksize)
             if verbose and verbose.upper() == 'TRUE':

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,6 +9,7 @@ import pathlib
 
 import dateutil.parser
 import pytest
+import requests
 import responses
 from responses import registries
 
@@ -1124,6 +1125,20 @@ def test_download_file(overwrite):
 
     if not overwrite:
         os.unlink(expected_filename)
+
+def test_download_file_raises_on_error_status():
+    # An error response must not be written to disk as if it were data.
+    expected_filename = 'pytest_error_tempfile.temp'
+    url = 'http://example.com/' + expected_filename
+
+    with responses.RequestsMock() as resp_mock:
+        resp_mock.add(responses.GET, url, body='Not authorized', status=403, stream=True)
+        client = Client(should_validate_auth=False)
+        with pytest.raises(requests.exceptions.HTTPError):
+            client._download_file(url, overwrite=True)
+
+    assert not os.path.isfile(expected_filename)
+
 
 def test_download_opendap_file():
     expected_data = bytes('abcde', encoding='utf-8')


### PR DESCRIPTION
## Jira Issue ID

None. I do not have Jira access, so the commit does not carry a HARMONY-XXXX prefix as CONTRIBUTING asks. Happy to reword the commit if you give me a ticket number.

## Description

`Client._download_file` streams the response body to disk without checking the status:

```python
with getattr(session, method)(new_url, data=data_dict, stream=True, headers=headers) as r:
    with open(filename, "wb") as f:
        shutil.copyfileobj(r.raw, f, length=chunksize)
```

If the request fails, the error body is written under the expected data filename and the function returns that filename as if the download succeeded. An expired token, a 403 from a restricted collection, or a Harmony error document all land on disk as a small file with the right name and the wrong contents. `download`, `download_all` and the generator paths all go through this method, so the caller sees no error at all. Worse, on a later run the `not overwrite and os.path.isfile(filename)` short circuit treats that error file as an already-downloaded product and skips the fetch.

Adding `r.raise_for_status()` before opening the file surfaces the failure as `requests.exceptions.HTTPError` and leaves nothing behind on disk. The futures in `download_all` already propagate exceptions when the caller resolves them, so this reaches the user rather than being silently swallowed.

## Local Test Steps

Added `test_download_file_raises_on_error_status` to tests/test_client.py: a mocked 403 with a body must raise HTTPError and must not create the file. Before the change the test fails, and the leftover file on disk contains "Not authorized", which is exactly the failure mode.

`pytest tests/` on Python 3.12 gives 231 passed with the change (230 before, plus the new test). The two `test_request_as_curl_*` failures are pre-existing on main and unrelated. `flake8 harmony/client.py` is clean.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)