### PR TITLE
HARMONY-2382 Add download_intermediate_files helper function.

### DIFF
--- a/examples/job_step_results.ipynb
+++ b/examples/job_step_results.ipynb
@@ -133,7 +133,7 @@
     "`download_intermediate_files` resolves a work item's input and/or output files\n",
     "and downloads them for you, returning a `Future` per file just like\n",
     "`download_all`. To prevent accidentally downloading many files, it is limited\n",
-    "to the first 50 files, printing a warning if more were available.\n"
+    "to the first 50 files, printing a warning if more than 50 files were resolved.\n"
    ]
   },
   {
@@ -156,7 +156,7 @@
    "source": [
     "#### Download more than 50 files \n",
     "\n",
-    "To bypass the 50 file limit on the `download_intermediate_files` helper, you can always download the files directly by resolving them with a `StepsRequest` and then passing each URL to `client.download()`. "
+    "If you must, you can bypass the 50 file limit on the `download_intermediate_files` helper, by downloading the files directly by first resolving them with a `StepsRequest` and then passing each URL to `client.download()`. "
    ]
   },
   {

--- a/examples/job_step_results.ipynb
+++ b/examples/job_step_results.ipynb
@@ -57,7 +57,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Form a simple request to the steps endpoint"
+    "### Make a simple request to the steps endpoint"
    ]
   },
   {
@@ -128,7 +128,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Download the input and output files "
+    "### Download intermediate files\n",
+    "\n",
+    "`download_intermediate_files` resolves a work item's input and/or output files\n",
+    "and downloads them for you, returning a `Future` per file just like\n",
+    "`download_all`. To prevent accidentally downloading many files, it is limited\n",
+    "to the first 50 files, printing a warning if more were available.\n"
    ]
   },
   {
@@ -137,8 +142,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "input_file = response[\"steps\"][0][\"workItems\"][0][\"inputFiles\"][0]\n",
-    "output_file = response[\"steps\"][0][\"workItems\"][0][\"outputFiles\"][0]"
+    "futures = harmony_client.download_intermediate_files(\n",
+    "    job_id,\n",
+    "    work_items=[workitem_id],\n",
+    ")\n",
+    "downloaded_paths = [future.result() for future in futures]\n",
+    "downloaded_paths"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Download more than 50 files \n",
+    "\n",
+    "To bypass the 50 file limit on the `download_intermediate_files` helper, you can always download the files directly by resolving them with a `StepsRequest` and then passing each URL to `client.download()`. "
    ]
   },
   {
@@ -147,8 +165,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!curl -n -L -o \"Soil_Moisture_Retrieval_Data_landcover_class_fraction_subsetted.h5\" \"{input_file}\"\n",
-    "!curl -n -L -o \"Soil_Moisture_Retrieval_Data_landcover_class_fraction_subsetted_regridded.nc\" \"{output_file}\""
+    "work_item = response[\"steps\"][0][\"workItems\"][0]\n",
+    "all_urls = work_item.get(\"inputFiles\", []) + work_item.get(\"outputFiles\", [])\n",
+    "\n",
+    "all_futures = [harmony_client.download(url) for url in all_urls]\n",
+    "all_paths = [future.result() for future in all_futures]\n",
+    "all_paths"
    ]
   },
   {

--- a/examples/job_step_results.ipynb
+++ b/examples/job_step_results.ipynb
@@ -188,7 +188,7 @@
     "- `work_item_output_pages={work_item_id: page}` &rarr; `workItem<work_item_id>outputPage=<page>`\n",
     "\n",
     "Use `request_as_url` to see how the dictionaries translate into query parameters\n",
-    "without submitting the request, since it is invalid for our test case."
+    "without actually submitting the request, since it's invalid for our test case."
    ]
   },
   {

--- a/harmony/client.py
+++ b/harmony/client.py
@@ -1039,7 +1039,7 @@ class Client:
         include_outputs: bool = True,
         directory: str = '',
         overwrite: bool = False,
-    ) -> Generator[Future, None, None]:
+    ) -> Iterator[Future]:
         """Resolve and download the intermediate input and/or output files for
         one or more of a job's workItems.
 
@@ -1060,7 +1060,7 @@ class Client:
                 file. Defaults to False (a duplicate filename is not downloaded again.).
 
         Returns:
-            A generator of Futures, each of which resolves to the filename (with path) of a
+            A iterator of Futures, each of which resolves to the filename (with path) of a
             downloaded file.
 
         Raises:

--- a/harmony/client.py
+++ b/harmony/client.py
@@ -1047,8 +1047,7 @@ class Client:
         downloads them using the same mechanism as ``download_all``.
 
         To prevent accidental download of many files, this helper
-        downloads at most ``MAX_INTERMEDIATE_FILE_DOWNLOADS`` (50) files, in the
-        order the services produced them.
+        limits the number of files to ``MAX_INTERMEDIATE_FILE_DOWNLOADS`` (50).
 
         Args:
             job_id: UUID string for the job whose intermediate files you want.

--- a/harmony/client.py
+++ b/harmony/client.py
@@ -56,6 +56,9 @@ DEFAULT_JOB_LABEL = "harmony-py"
 
 MAX_INTERMEDIATE_FILE_DOWNLOADS = 50
 
+# Sentinel value that Harmony's steps endpoint produces when a intermediate
+# result cannot be turned into a public/valid link. We have to avoid
+# attempting to download this value.
 PRIVATE_FILE_LOCATION = '<private file location>'
 
 progressbar_widgets = [

--- a/harmony/client.py
+++ b/harmony/client.py
@@ -1054,8 +1054,8 @@ class Client:
             work_items: A non-empty list of work item ids to retrieve files from.
             include_inputs: Whether to download each work item's input files. Defaults to True.
             include_outputs: Whether to download each work item's output files. Defaults to True.
-            directory: Optional. If specified, location for downloaded files. Defaults to the current
-                working directory.
+            directory: Optional. If specified, location for downloaded files.
+                Defaults to the current working directory.
             overwrite: If True, overwrites a local file that shares a filename with the downloaded
                 file. Defaults to False (a duplicate filename is not downloaded again.).
 

--- a/harmony/client.py
+++ b/harmony/client.py
@@ -54,6 +54,10 @@ from harmony import __version__ as harmony_version
 
 DEFAULT_JOB_LABEL = "harmony-py"
 
+MAX_INTERMEDIATE_FILE_DOWNLOADS = 50
+
+PRIVATE_FILE_LOCATION = '<private file location>'
+
 progressbar_widgets = [
     ' [ Processing: ', progressbar.Percentage(), ' ] ',
     progressbar.Bar(),
@@ -140,7 +144,7 @@ class Client:
         auth: Optional[Tuple[str, str]] = None,
         should_validate_auth: bool = True,
         env: Environment = Environment.PROD,
-        token: str = None,
+        token: str | None = None,
         # How often to poll Harmony for updated information during job processing
         check_interval: float = 3.0  # in seconds
     ):
@@ -1026,6 +1030,78 @@ class Client:
                     if url.endswith('zarr'):
                         raise self.zarr_download_exception
                     yield self.executor.submit(self._download_file, url, directory, overwrite)
+
+    def download_intermediate_files(
+        self,
+        job_id: str,
+        work_items: List[int],
+        include_inputs: bool = True,
+        include_outputs: bool = True,
+        directory: str = '',
+        overwrite: bool = False,
+    ) -> Generator[Future, None, None]:
+        """Resolve and download the intermediate input and/or output files for
+        one or more of a job's workItems.
+
+        This helper resolves these files via the steps endpoint and
+        downloads them using the same mechanism as ``download_all``.
+
+        To prevent accidental download of many files, this helper
+        downloads at most ``MAX_INTERMEDIATE_FILE_DOWNLOADS`` (50) files, in the
+        order the services produced them.
+
+        Args:
+            job_id: UUID string for the job whose intermediate files you want.
+            work_items: A non-empty list of work item ids to retrieve files from.
+            include_inputs: Whether to download each work item's input files. Defaults to True.
+            include_outputs: Whether to download each work item's output files. Defaults to True.
+            directory: Optional. If specified, location for downloaded files. Defaults to the current
+                working directory.
+            overwrite: If True, overwrites a local file that shares a filename with the downloaded
+                file. Defaults to False (a duplicate filename is not downloaded again.).
+
+        Returns:
+            A generator of Futures, each of which resolves to the filename (with path) of a
+            downloaded file.
+
+        Raises:
+            ValueError: If ``work_items`` is empty or if neither ``include_inputs`` nor
+                ``include_outputs`` is True.
+
+        """
+        if not work_items:
+            raise ValueError('work_items must contain at least one work item id.')
+        if not include_inputs and not include_outputs:
+            raise ValueError(
+                'At least one of include_inputs or include_outputs must be True.')
+
+        request = StepsRequest(job_id=job_id, work_item=work_items, resolve_files=True)
+        response = self.submit(request)
+
+        urls = []
+        seen = set()
+        for step in response.get('steps', []):
+            for work_item in step.get('workItems', []):
+                files = []
+                if include_inputs:
+                    files += work_item.get('inputFiles', [])
+                if include_outputs:
+                    files += work_item.get('outputFiles', [])
+                for url in files:
+                    if url == PRIVATE_FILE_LOCATION or url in seen:
+                        continue
+                    seen.add(url)
+                    urls.append(url)
+
+        if len(urls) > MAX_INTERMEDIATE_FILE_DOWNLOADS:
+            print(f'\nFound {len(urls)} intermediate files; downloading the first '
+                  f'{MAX_INTERMEDIATE_FILE_DOWNLOADS}. To download all of them, '
+                  'resolve the files with a StepsRequest and pass each URL to download().',
+                  file=sys.stderr)
+            urls = urls[:MAX_INTERMEDIATE_FILE_DOWNLOADS]
+
+        for url in urls:
+            yield self.download(url, directory, overwrite)
 
     def iterator(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,7 +23,6 @@ from harmony.config import Environment
 def examples_dir():
     return pathlib.Path(__file__).parent.parent.joinpath('examples').absolute()
 
-
 def expected_submit_url(collection_id, variables='all'):
     return (f'https://harmony.earthdata.nasa.gov/{collection_id}'
             f'/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset')
@@ -2046,6 +2045,119 @@ def test_get_job_steps_resolve_files_without_work_item():
     assert str(e.value) == ('Cannot submit the request due to the following errors: '
                             '[resolve_files requires a work_item filter for StepsRequest]')
     assert len(responses.calls) == 0
+
+
+def _resolved_steps_response(job_id, input_files, output_files, work_item_id=985):
+    return {
+        'jobID': job_id,
+        'steps': [
+            {
+                'serviceID': 'service-name:latest',
+                'stepIndex': 1,
+                'workItems': [
+                    {
+                        'id': work_item_id,
+                        'status': 'successful',
+                        'inputFiles': input_files,
+                        'outputFiles': output_files,
+                    }
+                ],
+            }
+        ],
+    }
+
+
+@responses.activate
+def test_download_intermediate_files_downloads_inputs_and_outputs(tmp_path):
+    job_id = 'jobs-uuid'
+    input_url = 'http://example.com/input1.nc'
+    output_url = 'http://example.com/output1.nc'
+    resolved = _resolved_steps_response(job_id, [input_url], [output_url])
+
+    responses.add(responses.GET, expected_steps_url(job_id), status=200, json=resolved)
+    responses.add(responses.GET, input_url, body=b'input-data', stream=True)
+    responses.add(responses.GET, output_url, body=b'output-data', stream=True)
+
+    client = Client(should_validate_auth=False)
+    futures = list(
+        client.download_intermediate_files(
+            job_id, work_items=[985], directory=str(tmp_path)
+        )
+    )
+    paths = sorted(f.result() for f in futures)
+
+    assert paths == [os.path.join(str(tmp_path), 'input1.nc'),
+                     os.path.join(str(tmp_path), 'output1.nc')]
+    assert (tmp_path / 'input1.nc').read_bytes() == b'input-data'
+    assert (tmp_path / 'output1.nc').read_bytes() == b'output-data'
+    # The steps endpoint is resolved with the work item filter.
+    steps_url = responses.calls[0].request.url
+    assert 'resolveFiles=true' in steps_url
+    assert 'workItem=985' in steps_url
+
+
+@responses.activate
+def test_download_intermediate_files_inputs_only(tmp_path):
+    job_id = 'jobs-uuid'
+    input_url = 'http://example.com/input1.nc'
+    output_url = 'http://example.com/output1.nc'
+    resolved = _resolved_steps_response(job_id, [input_url], [output_url])
+
+    responses.add(responses.GET, expected_steps_url(job_id), status=200, json=resolved)
+    responses.add(responses.GET, input_url, body=b'input-data', stream=True)
+
+    client = Client(should_validate_auth=False)
+    futures = list(client.download_intermediate_files(
+        job_id, work_items=[985], include_outputs=False, directory=str(tmp_path)))
+    paths = [f.result() for f in futures]
+
+    assert paths == [os.path.join(str(tmp_path), 'input1.nc')]
+
+
+def test_download_intermediate_files_caps_at_50(mocker, capsys):
+    client = Client(should_validate_auth=False)
+    input_files = [f'http://example.com/f{i}.nc' for i in range(60)]
+    resolved = _resolved_steps_response('jobs-uuid', input_files, [])
+    mocker.patch.object(client, 'submit', return_value=resolved)
+    download_mock = mocker.patch.object(client, 'download', side_effect=lambda u, d, o: u)
+
+    results = list(client.download_intermediate_files('jobs-uuid', work_items=[985]))
+
+    assert len(results) == 50
+    assert download_mock.call_count == 50
+    assert 'Found 60 intermediate files' in capsys.readouterr().err
+
+
+def test_download_intermediate_files_skips_private_and_dedups(mocker):
+    client = Client(should_validate_auth=False)
+    files = [
+        'http://example.com/a.nc',
+        '<private file location>',
+        'http://example.com/a.nc',
+        'http://example.com/b.nc',
+    ]
+    resolved = _resolved_steps_response('jobs-uuid', files, [])
+    mocker.patch.object(client, 'submit', return_value=resolved)
+    mocker.patch.object(client, 'download', side_effect=lambda u, d, o: u)
+
+    results = list(client.download_intermediate_files('jobs-uuid', work_items=[985]))
+
+    assert results == ['http://example.com/a.nc', 'http://example.com/b.nc']
+
+
+def test_download_intermediate_files_requires_a_file_type():
+    client = Client(should_validate_auth=False)
+    with pytest.raises(ValueError):
+        list(client.download_intermediate_files(
+            'jobs-uuid', work_items=[985],
+            include_inputs=False, include_outputs=False))
+
+
+def test_download_intermediate_files_requires_work_items():
+    client = Client(should_validate_auth=False)
+    with pytest.raises(ValueError):
+        list(client.download_intermediate_files('jobs-uuid', work_items=[]))
+
 
 def test_client_environment_not_affected_by_env_var():
     os.environ['ENVIRONMENT'] = 'UAT'


### PR DESCRIPTION
## Jira Issue ID

[HARMONY-2382](https://bugs.earthdata.nasa.gov/browse/HARMONY-2382)

## Description

Adds `Client.download_intermediate_files` helper function to download a work item's intermediate files.
Helper is capped at 50 files max.
Updates documentation notebook to show sample usage and describe how to get all files if necessary.

## Local Test Steps

Pull this branch, install the code and run the tests.
```
❯ make install
❯ make lint
❯ make test
```

Run the notebook `examples/job_step_results.ipynb` See that the files get downloaded to your directory.


## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [X] Documentation updated (if needed)
