### PR TITLE
HARMONY-2420: Provide functions for submitting a batch of requests to harmony

### DIFF
--- a/examples/batch_processing.ipynb
+++ b/examples/batch_processing.ipynb
@@ -1,0 +1,243 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-0",
+   "metadata": {},
+   "source": [
+    "## Harmony Py Library\n",
+    "### Batch Processing Example\n",
+    "\n",
+    "This notebook demonstrates submitting many Harmony requests at once and processing them\n",
+    "as a batch, without having to track each job's completion individually. This is useful\n",
+    "when you have a large number of independent requests (e.g. one per granule, date range, or\n",
+    "region of interest) that you want to send quickly and collect results from once they're all\n",
+    "done.\n",
+    "\n",
+    "Three methods make this possible:\n",
+    "\n",
+    "* `submit_batch()` - submits a list of `Request` objects concurrently and returns a list of\n",
+    "  job IDs, in the same order as the requests.\n",
+    "* `wait_for_batch()` - waits for a list of job IDs to each reach a terminal state, polling\n",
+    "  them concurrently, and reports back which jobs succeeded and which failed.\n",
+    "* `download_batch()` - downloads the output files for a list of job IDs concurrently."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import helper\n",
+    "helper.install_project_and_dependencies('..')\n",
+    "\n",
+    "import datetime as dt\n",
+    "from harmony import BBox, Client, Collection, Request, Environment"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-2",
+   "metadata": {},
+   "source": [
+    "#### Build a batch of requests\n",
+    "\n",
+    "Here we build several independent subset requests against the same collection, each for a\n",
+    "different time range. In practice these might instead vary by spatial area, granule, or any\n",
+    "other criteria."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "harmony_client = Client(env=Environment.UAT)  # assumes .netrc usage\n",
+    "\n",
+    "collection = Collection(id='C1234088182-EEDTEST')\n",
+    "\n",
+    "time_ranges = [\n",
+    "    {\n",
+    "        'start': dt.datetime(2020, 1, 1),\n",
+    "        'stop': dt.datetime(2020, 1, 5),\n",
+    "    },\n",
+    "    {\n",
+    "        'start': dt.datetime(2020, 1, 1),\n",
+    "        'stop': dt.datetime(2020, 1, 5),\n",
+    "    },\n",
+    "    {\n",
+    "        'start': dt.datetime(2020, 2, 1),\n",
+    "        'stop': dt.datetime(2020, 2, 5),\n",
+    "    },\n",
+    "]\n",
+    "\n",
+    "requests = [Request(collection=collection, temporal=time_range, labels=['batch_submit']) for time_range in time_ranges]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5113a6f0-0933-4de9-a3bd-5773049aeacb",
+   "metadata": {},
+   "source": [
+    "##### Add a request that we know will fail due to an access issue downloading the file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6a2affa-b53e-4bd5-825d-92e3419d40b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "failing_request = Request(\n",
+    "    collection=Collection(id='C1234724470-POCLOUD'),\n",
+    "    spatial=BBox(-45,0,45,90),\n",
+    "    granule_id='G1236546414-POCLOUD'\n",
+    ")\n",
+    "requests.append(failing_request)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-4",
+   "metadata": {},
+   "source": [
+    "#### Submit the batch\n",
+    "\n",
+    "`submit_batch()` submits every request concurrently rather than waiting for each one to be\n",
+    "accepted before submitting the next, and returns the resulting job IDs in the same order as\n",
+    "`requests`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_ids = harmony_client.submit_batch(requests)\n",
+    "job_ids"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-6",
+   "metadata": {},
+   "source": [
+    "#### Wait for the batch to finish\n",
+    "\n",
+    "`wait_for_batch()` polls every job in the batch concurrently until each one reaches a\n",
+    "terminal state (`successful`, `failed`, `canceled`, `complete_with_errors`, or `paused`), and\n",
+    "returns a `BatchStatus` with a count and a list of job IDs for each status."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_status = harmony_client.wait_for_batch(job_ids, show_progress=True)\n",
+    "batch_status.counts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9072dfc2-2cad-4fb8-9048-28341ff00314",
+   "metadata": {},
+   "source": [
+    "##### Get the list of successful job ids."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_status.job_ids[\"successful\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-10",
+   "metadata": {},
+   "source": [
+    "#### Inspect any failures\n",
+    "\n",
+    "For jobs that didn't succeed, `status()` can be used to see why."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for job_id in batch_status.job_ids['failed']:\n",
+    "    status = harmony_client.status(job_id)\n",
+    "    print(job_id, status['status'], status['message'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-12",
+   "metadata": {},
+   "source": [
+    "#### Download the outputs\n",
+    "\n",
+    "`download_batch()` downloads the output files for every job in the batch concurrently and\n",
+    "returns a dict mapping each job ID to a list of `Future`s, one per output file. Calling\n",
+    "`.result()` on a `Future` blocks until that particular file finishes downloading and returns\n",
+    "its local filename.\n",
+    "\n",
+    "It's safe to pass every job ID from the batch, regardless of status — a job with no output\n",
+    "files (e.g. one that failed or has no results) just maps to an empty list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "downloads = harmony_client.download_batch(job_ids, directory='/tmp', overwrite=True)\n",
+    "\n",
+    "for job_id, futures in downloads.items():\n",
+    "    filenames = [f.result() for f in futures]\n",
+    "    print(f'{job_id}: {filenames}')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/harmony/__init__.py
+++ b/harmony/__init__.py
@@ -19,5 +19,5 @@ from harmony.request import (
     JobsRequest,
     StepsRequest,
 )
-from harmony.client import Client
+from harmony.client import BatchStatus, Client
 from harmony.util import s3_components

--- a/harmony/client.py
+++ b/harmony/client.py
@@ -218,7 +218,7 @@ class Client:
         num_workers = int(self.config.NUM_REQUESTS_WORKERS)
         self.executor = ThreadPoolExecutor(max_workers=num_workers)
 
-        # Tracks which download hosts have already completed EDL authentication to 
+        # Tracks which download hosts have already completed EDL authentication to
         # prevent multiple requests from simultaneously attempting and hitting errors.
         # See _host_lock().
         self._authenticated_hosts = set()

--- a/harmony/client.py
+++ b/harmony/client.py
@@ -24,6 +24,7 @@ import os
 import shutil
 import sys
 from tabnanny import check
+import threading
 import time
 import platform
 from uuid import UUID
@@ -39,6 +40,7 @@ from shapely.wkt import loads
 from typing import (
     Any,
     ContextManager,
+    Dict,
     IO,
     Iterator,
     List,
@@ -49,6 +51,7 @@ from typing import (
     Generator,
     Union,
 )
+from collections import defaultdict
 from urllib import parse
 
 import curlify
@@ -77,6 +80,13 @@ from harmony import __version__ as harmony_version
 DEFAULT_JOB_LABEL = 'harmony-py'
 
 MAX_INTERMEDIATE_FILE_DOWNLOADS = 50
+
+# Maximum number of job IDs the /jobs/status batch endpoint accepts per request.
+MAX_BATCH_STATUS_JOB_IDS = 2000
+
+# Job statuses from which a job will not transition to another status without user
+# intervention (e.g. resuming a paused job). Used to know when polling can stop for a job.
+TERMINAL_JOB_STATUSES = {'successful', 'failed', 'canceled', 'complete_with_errors', 'paused'}
 
 # Sentinel value that Harmony's steps endpoint produces when a intermediate
 # result cannot be turned into a public/valid link. We have to avoid
@@ -110,6 +120,20 @@ def temporal_to_edr_datetime(temporal: dict) -> str:
         stop_str = '..'
 
     return f'{start_str}/{stop_str}'
+
+
+class BatchStatus(NamedTuple):
+    """Status breakdown for a batch of jobs, as returned by ``wait_for_batch()``.
+
+    ``counts`` and ``job_ids`` are both keyed by job status (e.g. ``'successful'``,
+    ``'failed'``). Every status in ``TERMINAL_JOB_STATUSES`` is present even if no job in
+    the batch ended up in that status, and both are defaultdicts, so looking up any other
+    status (including one Harmony introduces in the future) returns ``0`` / ``[]`` rather
+    than raising a ``KeyError``.
+    """
+
+    counts: Dict[str, int]
+    job_ids: Dict[str, List[str]]
 
 
 class ProcessingFailedException(Exception):
@@ -194,6 +218,13 @@ class Client:
         num_workers = int(self.config.NUM_REQUESTS_WORKERS)
         self.executor = ThreadPoolExecutor(max_workers=num_workers)
 
+        # Tracks which download hosts have already completed EDL authentication to 
+        # prevent multiple requests from simultaneously attempting and hitting errors.
+        # See _host_lock().
+        self._authenticated_hosts = set()
+        self._host_locks_guard = threading.Lock()
+        self._host_locks: Dict[str, threading.Lock] = {}
+
         if should_validate_auth:
             validate_auth(self.config, self._session())
 
@@ -204,12 +235,13 @@ class Client:
                 self.session = create_session(self.config, token=self.token)
             else:
                 self.session = create_session(self.config, auth=self.auth)
-            # Add retry logic
             retry_strategy = Retry(
-                total=3,
-                backoff_factor=1,  # Wait 1, 2, 4 seconds between retries
-                status_forcelist=[429, 500, 502, 503, 504],
-                allowed_methods=['GET'],
+                total=5,
+                backoff_factor=1,  # Exponential: 1, 2, 4, 8, 16s, before jitter/capping below
+                backoff_jitter=1,  # Adds a random 0-1s to each wait to avoid thundering herd
+                backoff_max=5,  # No single retry waits longer than 5 seconds
+                status_forcelist=[429, *range(500, 600)],
+                allowed_methods=['GET', 'POST'],
                 raise_on_status=False,
             )
             adapter = HTTPAdapter(max_retries=retry_strategy)
@@ -258,6 +290,10 @@ class Client:
     def _status_url(self, job_id: str, link_type: LinkType = LinkType.https) -> str:
         """Constructs the URL for the Job that is used to get its status."""
         return f'{self.config.root_url}/jobs/{job_id}?linktype={link_type.value}'
+
+    def _job_status_batch_url(self) -> str:
+        """Constructs the URL for the lightweight batch job status endpoint."""
+        return f'{self.config.root_url}/jobs/status'
 
     def _pause_url(self, job_id: str, link_type: LinkType = LinkType.https) -> str:
         """Constructs the URL for the Job that is used to pause it."""
@@ -599,6 +635,29 @@ class Client:
         else:
             self._handle_error_response(response)
 
+    def submit_batch(self, requests: List[BaseRequest]) -> List[any]:
+        """Submits a batch of requests to Harmony concurrently.
+
+        This is a convenience wrapper around calling ``submit()`` once per request, useful
+        when you have many requests to send and don't want to wait for each one to be
+        accepted before submitting the next.
+
+        Args:
+            requests: The Requests to submit to Harmony (each will be validated before
+                sending, same as ``submit()``).
+
+        Returns:
+            A list of results, in the same order as ``requests``, one per request as
+            returned by ``submit()`` (typically a Harmony Job ID).
+
+        Raises:
+            Exception: If any individual submission fails, the corresponding exception is
+                raised once that submission's result is reached. Other submissions in the
+                batch are not canceled.
+        """
+        futures = [self.executor.submit(self.submit, request) for request in requests]
+        return [future.result() for future in futures]
+
     def status(self, job_id: str) -> dict:
         """Retrieve a submitted job's metadata from Harmony.
 
@@ -737,6 +796,72 @@ class Client:
         else:
             self._handle_error_response(response)
 
+    def _poll_job_statuses(self, job_ids: List[str]) -> dict:
+        """Fetches status and progress for a batch of jobs using the lightweight batch
+        status endpoint, making as few HTTP calls as possible.
+
+        Args:
+            job_ids: The Harmony Job IDs to look up. Chunked into requests of at most
+                ``MAX_BATCH_STATUS_JOB_IDS`` job IDs each.
+
+        Returns:
+            A dict mapping each job ID to a dict with ``status`` and ``progress`` keys.
+
+        Raises:
+            Exception: If any of the job IDs could not be found, or a request fails.
+        """
+        session = self._session()
+        statuses = {}
+        for i in range(0, len(job_ids), MAX_BATCH_STATUS_JOB_IDS):
+            chunk = job_ids[i : i + MAX_BATCH_STATUS_JOB_IDS]
+            response = session.post(self._job_status_batch_url(), json={'jobIDs': chunk})
+            if response.ok:
+                body = response.json()
+                not_found = body.get('notFoundJobIDs') or []
+                if not_found:
+                    raise Exception(f'Could not find job(s): {", ".join(not_found)}')
+                for job_status in body['jobStatuses']:
+                    statuses[job_status['jobID']] = job_status
+            else:
+                self._handle_error_response(response)
+        return statuses
+
+    def _poll_progress(self, job_id: str) -> Tuple[int, str]:
+        """Fetches a single job's progress and status via the lightweight batch status
+        endpoint.
+
+        Args:
+            job_id: UUID string for the job to poll.
+
+        Returns:
+            A tuple of the job's processing progress as a percentage and its processing
+            state.
+        """
+        job_status = self._poll_job_statuses([job_id])[job_id]
+        return int(job_status['progress']), job_status['status']
+
+    def _poll_status_and_message(self, job_id: str) -> Tuple[int, str, Optional[str]]:
+        """Polls a job's progress and status via the lightweight batch status endpoint.
+
+        Once the job reaches a terminal status, makes one additional call to
+        ``progress()`` (the full ``/jobs/{id}`` endpoint) to fetch the authoritative status
+        message, exactly as callers would have gotten before this endpoint existed.
+
+        Args:
+            job_id: UUID string for the job to poll.
+
+        Returns:
+            A tuple of the job's processing progress as a percentage, its processing state,
+            and its status message (``None`` if the job has not yet reached a terminal
+            status).
+        """
+        progress, status = self._poll_progress(job_id)
+        if status in TERMINAL_JOB_STATUSES:
+            progress, status, message = self.progress(job_id)
+        else:
+            message = None
+        return progress, status, message
+
     def wait_for_processing(self, job_id: str, show_progress: bool = False) -> None:
         """Retrieve a submitted job's completion status in percent.
 
@@ -759,7 +884,7 @@ class Client:
             with progressbar.ProgressBar(max_value=100, widgets=progressbar_widgets) as bar:
                 progress = 0
                 while progress < 100:
-                    progress, status, message = self.progress(job_id)
+                    progress, status, message = self._poll_status_and_message(job_id)
                     if status == 'failed':
                         raise ProcessingFailedException(job_id, message)
                     if status == 'canceled':
@@ -788,7 +913,7 @@ class Client:
         else:
             progress = 0
             while progress < 100:
-                progress, status, message = self.progress(job_id)
+                progress, status, message = self._poll_status_and_message(job_id)
                 if status == 'failed':
                     raise ProcessingFailedException(job_id, message)
                 if status == 'canceled':
@@ -800,6 +925,58 @@ class Client:
                     print('\nJob is running with errors.', file=sys.stderr)
                     running_w_errors_logged = True
                 time.sleep(self.check_interval)
+
+    def wait_for_batch(self, job_ids: List[str], show_progress: bool = False) -> BatchStatus:
+        """Waits for a batch of jobs to each reach a terminal state, polling all of them in
+        as few HTTP calls as possible rather than polling one job at a time.
+
+        Args:
+            job_ids: The Harmony Job IDs to wait for.
+            show_progress: Whether a progress bar should show via stdout, tracking how many
+                of the jobs have reached a terminal state.
+
+        Returns:
+            A BatchStatus with ``counts`` (number of jobs per final status) and ``job_ids``
+            (the list of job IDs per final status).
+        """
+        pending_job_ids = list(job_ids)
+        final_status_by_job_id = {}
+
+        def poll_round():
+            nonlocal pending_job_ids
+            statuses = self._poll_job_statuses(pending_job_ids)
+            still_pending = []
+            for job_id, job_status in statuses.items():
+                if job_status['status'] in TERMINAL_JOB_STATUSES:
+                    final_status_by_job_id[job_id] = job_status['status']
+                else:
+                    still_pending.append(job_id)
+            pending_job_ids = still_pending
+
+        if show_progress:
+            with progressbar.ProgressBar(
+                max_value=len(job_ids), widgets=progressbar_widgets
+            ) as bar:
+                while pending_job_ids:
+                    poll_round()
+                    bar.update(len(job_ids) - len(pending_job_ids))
+                    if pending_job_ids:
+                        time.sleep(self.check_interval)
+        else:
+            while pending_job_ids:
+                poll_round()
+                if pending_job_ids:
+                    time.sleep(self.check_interval)
+
+        job_ids_by_status = defaultdict(list)
+        for status in TERMINAL_JOB_STATUSES:
+            job_ids_by_status[status]  # seed known statuses so they're always present
+        for job_id in job_ids:
+            job_ids_by_status[final_status_by_job_id[job_id]].append(job_id)
+
+        counts = defaultdict(int, {status: len(ids) for status, ids in job_ids_by_status.items()})
+
+        return BatchStatus(counts=counts, job_ids=job_ids_by_status)
 
     def result_json(
         self, job_id: str, show_progress: bool = False, link_type: LinkType = LinkType.https
@@ -925,6 +1102,39 @@ class Client:
             name_result = f'{item_id}_{original_filename}'
         return name_result.replace(':', '_')
 
+    def _host_lock(self, host: str) -> threading.Lock:
+        """Returns a lock specific to the given host, creating it on first use."""
+        with self._host_locks_guard:
+            if host not in self._host_locks:
+                self._host_locks[host] = threading.Lock()
+            return self._host_locks[host]
+
+    def _fetch_and_save_file(
+        self, session, url: str, filename: str, chunksize: int, verbose: bool
+    ) -> None:
+        """Issues the actual HTTP request for ``_download_file`` and writes the response
+        body to ``filename``. Split out so the very first request to a given host can be
+        serialized (see ``_download_file``) without also serializing every subsequent
+        request to that host.
+        """
+        data_dict = None
+        parse_result = parse.urlparse(url)
+        is_opendap = parse_result.netloc.startswith('opendap')
+        method = 'post' if is_opendap else 'get'
+        new_url = url
+        if is_opendap:  # remove the query params from the URL and convert to dict
+            new_url = parse.urlunparse(parse_result._replace(query=''))
+            data_dict = dict(parse.parse_qsl(parse.urlsplit(url).query))
+        headers = {'Accept-Encoding': 'identity'}
+        with getattr(session, method)(new_url, data=data_dict, stream=True, headers=headers) as r:
+            # Without this an error response body (a 401 page, a Harmony
+            # error document) is written to disk and looks like data.
+            r.raise_for_status()
+            with open(filename, 'wb') as f:
+                shutil.copyfileobj(r.raw, f, length=chunksize)
+        if verbose:
+            print(filename)
+
     def _download_file(self, url: str, directory: str = '', overwrite: bool = False) -> str:
         """Downloads data, saves it to a file, and returns the filename.
 
@@ -949,36 +1159,37 @@ class Client:
         chunksize = int(self.config.DOWNLOAD_CHUNK_SIZE)
         session = self._session()
         filename = self.get_download_filename_from_url(url)
-        new_url = url
 
         if directory:
             filename = os.path.join(directory, filename)
 
-        verbose = os.getenv('VERBOSE', 'TRUE')
+        verbose_env = os.getenv('VERBOSE', 'TRUE')
+        verbose = bool(verbose_env and verbose_env.upper() == 'TRUE')
         if not overwrite and os.path.isfile(filename):
-            if verbose and verbose.upper() == 'TRUE':
+            if verbose:
                 print(filename)
             return filename
+
+        host = parse.urlparse(url).hostname
+        if host in self._authenticated_hosts:
+            self._fetch_and_save_file(session, url, filename, chunksize, verbose)
         else:
-            data_dict = None
-            parse_result = parse.urlparse(url)
-            is_opendap = parse_result.netloc.startswith('opendap')
-            method = 'post' if is_opendap else 'get'
-            if is_opendap:  # remove the query params from the URL and convert to dict
-                new_url = parse.urlunparse(parse_result._replace(query=''))
-                data_dict = dict(parse.parse_qsl(parse.urlsplit(url).query))
-            headers = {'Accept-Encoding': 'identity'}
-            with getattr(session, method)(
-                new_url, data=data_dict, stream=True, headers=headers
-            ) as r:
-                # Without this an error response body (a 401 page, a Harmony
-                # error document) is written to disk and looks like data.
-                r.raise_for_status()
-                with open(filename, 'wb') as f:
-                    shutil.copyfileobj(r.raw, f, length=chunksize)
-            if verbose and verbose.upper() == 'TRUE':
-                print(filename)
-            return filename
+            # The first request to a not-yet-seen host has to complete EDL authentication
+            # with multiple redirects and saving cookies before it can download data. That
+            # isn't safe to run concurrently: a second request racing through it on the same
+            # session can invalidate the first request's in-flight authorization code/state,
+            # surfacing as a 400 from Harmony's /oauth2/redirect callback. So the first
+            # request per host is serialized here; once it succeeds, the host is marked
+            # authenticated and every later request (including ones that were waiting
+            # on this lock) proceeds concurrently as normal.
+            with self._host_lock(host):
+                if host not in self._authenticated_hosts:
+                    self._fetch_and_save_file(session, url, filename, chunksize, verbose)
+                    self._authenticated_hosts.add(host)
+                    return filename
+            # Host became authenticated while we were waiting for the lock above.
+            self._fetch_and_save_file(session, url, filename, chunksize, verbose)
+        return filename
 
     def job_status_message(self, job_id: str) -> str:
         """Extract the job status and message from job results.
@@ -1071,6 +1282,58 @@ class Client:
                     if url.endswith('zarr'):
                         raise self.zarr_download_exception
                     yield self.executor.submit(self._download_file, url, directory, overwrite)
+
+    def _download_job_files(
+        self, job_id: str, directory: str = '', overwrite: bool = False
+    ) -> List[Future]:
+        """Blocks until the given job finishes processing, then submits downloads for all of
+        its output files.
+
+        Args:
+            job_id: UUID string for the job whose output files should be downloaded.
+            directory: Optional. If specified, saves files there. Saves files to the current
+            working directory by default.
+            overwrite: If True, will overwrite a local file that shares a filename with the
+            downloaded file. Defaults to False.
+
+        Returns:
+            A list of Futures, each of which will return the filename (with path) for one of
+            the job's output files.
+        """
+        return list(self.download_all(job_id, directory, overwrite))
+
+    def download_batch(
+        self, job_ids: List[str], directory: str = '', overwrite: bool = False
+    ) -> Mapping[str, List[Future]]:
+        """Downloads the output files for a batch of jobs.
+
+        Each job's outputs are resolved and downloaded the same way as ``download_all()``,
+        but jobs in the batch are waited on and downloaded concurrently rather than one at a
+        time. As with ``download_all()``, this call blocks until each job finishes
+        processing, but the actual file downloads happen asynchronously via the returned
+        Futures.
+
+        It's safe to pass job IDs regardless of status (e.g. the full batch passed to
+        ``wait_for_batch()``, not just its successful ones) — a job with no output files,
+        whatever its status, simply maps to an empty list rather than raising.
+
+        Args:
+            job_ids: The Harmony Job IDs to download outputs for.
+            directory: Optional. If specified, saves files there. Saves files to the current
+            working directory by default.
+            overwrite: If True, will overwrite a local file that shares a filename with the
+            downloaded file. Defaults to False.
+
+        Returns:
+            A dict mapping each job ID to a list of Futures, each of which will return the
+            filename (with path) for one of that job's output files. A job with no output
+            files (e.g. one that failed) maps to an empty list.
+        """
+        futures_by_job_id = {
+            job_id: self.executor.submit(self._download_job_files, job_id, directory, overwrite)
+            for job_id in job_ids
+        }
+        return {job_id: future.result() for job_id, future in futures_by_job_id.items()}
 
     def download_intermediate_files(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,8 +1,12 @@
+from concurrent.futures import ThreadPoolExecutor
 import copy
 import datetime as dt
 import io
+import json
 import os
 import re
+import threading
+import time
 from typing import List
 import urllib.parse
 import pathlib
@@ -44,6 +48,10 @@ def expected_submit_url(collection_id, variables='all'):
 
 def expected_status_url(job_id, link_type: LinkType = LinkType.https):
     return f'https://harmony.earthdata.nasa.gov/jobs/{job_id}?linktype={link_type.value}'
+
+
+def expected_job_status_batch_url():
+    return 'https://harmony.earthdata.nasa.gov/jobs/status'
 
 
 def expected_pause_url(job_id, link_type: LinkType = LinkType.https):
@@ -798,6 +806,71 @@ def test_progress():
 
 
 @responses.activate
+def test_poll_job_statuses():
+    job_ids = ['job-1', 'job-2']
+    exp_body = {
+        'jobStatuses': [
+            {'jobID': 'job-1', 'status': 'running', 'progress': 42},
+            {'jobID': 'job-2', 'status': 'successful', 'progress': 100},
+        ],
+        'notFoundJobIDs': [],
+    }
+    responses.add(
+        responses.POST, expected_job_status_batch_url(), status=200, json=exp_body
+    )
+
+    statuses = Client(should_validate_auth=False)._poll_job_statuses(job_ids)
+
+    assert len(responses.calls) == 1
+    assert json.loads(responses.calls[0].request.body) == {'jobIDs': job_ids}
+    assert statuses == {
+        'job-1': {'jobID': 'job-1', 'status': 'running', 'progress': 42},
+        'job-2': {'jobID': 'job-2', 'status': 'successful', 'progress': 100},
+    }
+
+
+@responses.activate
+def test_poll_job_statuses_chunks_large_batches():
+    job_ids = [f'job-{i}' for i in range(4001)]
+
+    def make_response(request):
+        chunk = json.loads(request.body)['jobIDs']
+        body = {
+            'jobStatuses': [
+                {'jobID': job_id, 'status': 'successful', 'progress': 100} for job_id in chunk
+            ],
+            'notFoundJobIDs': [],
+        }
+        return (200, {}, json.dumps(body))
+
+    responses.add_callback(
+        responses.POST, expected_job_status_batch_url(), callback=make_response
+    )
+
+    statuses = Client(should_validate_auth=False)._poll_job_statuses(job_ids)
+
+    assert len(responses.calls) == 3
+    call_sizes = [len(json.loads(call.request.body)['jobIDs']) for call in responses.calls]
+    assert call_sizes == [2000, 2000, 1]
+    assert len(statuses) == len(job_ids)
+
+
+@responses.activate
+def test_poll_job_statuses_raises_on_not_found():
+    job_ids = ['job-1', 'missing-job']
+    exp_body = {
+        'jobStatuses': [{'jobID': 'job-1', 'status': 'successful', 'progress': 100}],
+        'notFoundJobIDs': ['missing-job'],
+    }
+    responses.add(
+        responses.POST, expected_job_status_batch_url(), status=200, json=exp_body
+    )
+
+    with pytest.raises(Exception, match='missing-job'):
+        Client(should_validate_auth=False)._poll_job_statuses(job_ids)
+
+
+@responses.activate
 def test_pause():
     collection = Collection(id='C333666999-EOSDIS')
     job_id = '21469294-d6f7-42cc-89f2-c81990a5d7f4'
@@ -901,11 +974,15 @@ def test_cancel_conflict_error():
     ],
 )
 def test_wait_for_processing_with_show_progress(mocker, show_progress):
+    # Each tick of the polling loop calls the lightweight _poll_progress() (no message);
+    # only once a terminal status is reached does the loop make one more call to the full
+    # progress() to get the authoritative message.
     expected_progress = [
-        (80, 'running', 'The job is being processed'),
-        (90, 'running', 'The job is being processed'),
-        (100, 'successful', 'The job was successful'),
+        (80, 'running'),
+        (90, 'running'),
+        (100, 'successful'),
     ]
+    expected_final = (100, 'successful', 'The job was successful')
     job_id = '12345'
 
     progressbar_mock = mocker.Mock()
@@ -916,15 +993,20 @@ def test_wait_for_processing_with_show_progress(mocker, show_progress):
     sleep_mock = mocker.Mock()
     mocker.patch('harmony.client.time.sleep', sleep_mock)
 
-    progress_mock = mocker.Mock(side_effect=expected_progress)
+    poll_progress_mock = mocker.Mock(side_effect=expected_progress)
+    mocker.patch('harmony.client.Client._poll_progress', poll_progress_mock)
+
+    progress_mock = mocker.Mock(return_value=expected_final)
     mocker.patch('harmony.client.Client.progress', progress_mock)
 
     client = Client(should_validate_auth=False)
     client.wait_for_processing(job_id, show_progress=show_progress)
 
-    progress_mock.assert_called_with(job_id)
+    poll_progress_mock.assert_called_with(job_id)
+    assert poll_progress_mock.call_count == len(expected_progress)
+    progress_mock.assert_called_once_with(job_id)
     if show_progress:
-        for n, _, _ in expected_progress:
+        for n, _ in expected_progress:
             progressbar_mock.update.assert_any_call(int(n))
     else:
         assert sleep_mock.call_count == len(expected_progress)
@@ -938,7 +1020,6 @@ def test_wait_for_processing_with_show_progress(mocker, show_progress):
     ],
 )
 def test_wait_for_processing_with_failed_status(mocker, show_progress):
-    expected_progress = [(0, 'failed', 'Pod exploded')]
     job_id = '12345'
 
     progressbar_mock = mocker.Mock()
@@ -946,7 +1027,10 @@ def test_wait_for_processing_with_failed_status(mocker, show_progress):
     progressbar_mock.__exit__ = lambda a, b, d, c: None
     mocker.patch('harmony.client.progressbar.ProgressBar', return_value=progressbar_mock)
 
-    progress_mock = mocker.Mock(side_effect=expected_progress)
+    poll_progress_mock = mocker.Mock(side_effect=[(0, 'failed')])
+    mocker.patch('harmony.client.Client._poll_progress', poll_progress_mock)
+
+    progress_mock = mocker.Mock(side_effect=[(0, 'failed', 'Pod exploded')])
     mocker.patch('harmony.client.Client.progress', progress_mock)
 
     client = Client(should_validate_auth=False)
@@ -965,8 +1049,8 @@ def test_wait_for_processing_with_failed_status(mocker, show_progress):
 )
 def test_wait_for_processing_with_paused_status(mocker, show_progress):
     expected_progress = [
-        (10, 'running', 'The job is being processed'),
-        (10, 'paused', 'Job paused'),
+        (10, 'running'),
+        (10, 'paused'),
     ]
     job_id = '12345'
 
@@ -978,15 +1062,19 @@ def test_wait_for_processing_with_paused_status(mocker, show_progress):
     progressbar_mock.__exit__ = lambda a, b, d, c: None
     mocker.patch('harmony.client.progressbar.ProgressBar', return_value=progressbar_mock)
 
-    progress_mock = mocker.Mock(side_effect=expected_progress)
+    poll_progress_mock = mocker.Mock(side_effect=expected_progress)
+    mocker.patch('harmony.client.Client._poll_progress', poll_progress_mock)
+
+    progress_mock = mocker.Mock(side_effect=[(10, 'paused', 'Job paused')])
     mocker.patch('harmony.client.Client.progress', progress_mock)
 
     client = Client(should_validate_auth=False)
     client.wait_for_processing(job_id, show_progress=show_progress)
 
-    progress_mock.assert_called_with(job_id)
+    poll_progress_mock.assert_called_with(job_id)
+    progress_mock.assert_called_once_with(job_id)
     if show_progress:
-        for n, _, _ in expected_progress:
+        for n, _ in expected_progress:
             progressbar_mock.update.assert_any_call(int(n))
     else:
         # sleep should be called just once since the second status update returned 'paused'
@@ -1207,6 +1295,66 @@ def test_download_opendap_file():
         assert data == expected_data
 
     os.unlink(actual_output)
+
+
+def test_download_file_marks_host_authenticated_after_success():
+    filename = 'pytest_marks_host_authenticated.temp'
+    url = 'http://example.com/' + filename
+
+    with responses.RequestsMock() as resp_mock:
+        resp_mock.add(responses.GET, url, body=b'abcde', stream=True)
+        client = Client(should_validate_auth=False)
+        client._download_file(url, overwrite=True)
+
+    assert 'example.com' in client._authenticated_hosts
+    os.unlink(filename)
+
+
+def test_download_file_skips_host_lock_once_authenticated(mocker):
+    filename = 'pytest_already_authenticated.temp'
+    url = 'http://example.com/' + filename
+    client = Client(should_validate_auth=False)
+    client._authenticated_hosts.add('example.com')
+    host_lock_spy = mocker.spy(client, '_host_lock')
+
+    with responses.RequestsMock() as resp_mock:
+        resp_mock.add(responses.GET, url, body=b'abcde', stream=True)
+        client._download_file(url, overwrite=True)
+
+    host_lock_spy.assert_not_called()
+    os.unlink(filename)
+
+
+def test_download_file_serializes_first_request_per_host(mocker):
+    client = Client(should_validate_auth=False)
+    host = 'example.com'
+    url_a = f'http://{host}/a.temp'
+    url_b = f'http://{host}/b.temp'
+
+    a_started = threading.Event()
+    release_a = threading.Event()
+    b_ran_concurrently = threading.Event()
+
+    def fake_fetch(session, url, filename, chunksize, verbose):
+        if url == url_a:
+            a_started.set()
+            release_a.wait(timeout=2)
+        elif not release_a.is_set():
+            b_ran_concurrently.set()
+
+    mocker.patch.object(client, '_fetch_and_save_file', side_effect=fake_fetch)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        future_a = executor.submit(client._download_file, url_a, '', True)
+        assert a_started.wait(timeout=2)
+        future_b = executor.submit(client._download_file, url_b, '', True)
+        time.sleep(0.05)  # give b a chance to (incorrectly) run before a finishes
+        release_a.set()
+        future_a.result(timeout=2)
+        future_b.result(timeout=2)
+
+    assert not b_ran_concurrently.is_set()
+    assert host in client._authenticated_hosts
 
 
 def test_download_all(mocker):
@@ -1529,7 +1677,7 @@ def test_handle_error_response_with_description_key():
     with pytest.raises(Exception) as e:
         Client(should_validate_auth=False).progress(job_id)
     assert str(e.value) == f"('Internal Server Error', '{error['description']}')"
-    assert len(responses.calls) == 9
+    assert len(responses.calls) == 18  # (6 + 6 + 6): submit, status, and progress all retry
 
 
 @responses.activate
@@ -1552,7 +1700,7 @@ def test_handle_error_response_no_description_key():
         Client(should_validate_auth=False).progress(job_id)
     assert '500 Server Error: Internal Server Error for url' in str(e.value)
     # Check retries
-    assert len(responses.calls) == 9  # (1 + 4 + 4) # Post isn't retried.
+    assert len(responses.calls) == 18  # (6 + 6 + 6): submit, status, and progress all retry
 
 
 @responses.activate
@@ -1574,7 +1722,7 @@ def test_handle_error_response_no_json():
         Client(should_validate_auth=False).progress(job_id)
     assert '500 Server Error: Internal Server Error for url' in str(e.value)
     # Check retries
-    assert len(responses.calls) == 9  # (1 + 4 + 4)
+    assert len(responses.calls) == 18  # (6 + 6 + 6): submit, status, and progress all retry
 
 
 @responses.activate
@@ -1596,7 +1744,7 @@ def test_handle_error_response_invalid_json():
         Client(should_validate_auth=False).progress(job_id)
     assert '500 Server Error: Internal Server Error for url' in str(e.value)
     # Check retries
-    assert len(responses.calls) == 9  # (1 + 4 + 4)
+    assert len(responses.calls) == 18  # (6 + 6 + 6): submit, status, and progress all retry
 
 
 @responses.activate
@@ -1707,6 +1855,124 @@ def test_handle_transient_error_responses():
     assert first_retry.call_count == 1
     assert second_retry.call_count == 1
     assert last_success.call_count == 1
+
+
+def test_session_retry_configuration():
+    """The shared retry policy should allow up to 5 retries, cap any single
+    wait at 5 seconds, apply jitter, and cover both GET and POST (submit,
+    submit_batch, and job-status polling all rely on this)."""
+    client = Client(should_validate_auth=False)
+    adapter = client._session().get_adapter('https://harmony.earthdata.nasa.gov')
+    retry = adapter.max_retries
+
+    assert retry.total == 5
+    assert retry.backoff_max == 5
+    assert retry.backoff_jitter > 0
+    assert retry.raise_on_status is False
+    assert 'GET' in retry.allowed_methods
+    assert 'POST' in retry.allowed_methods
+    assert all(status in retry.status_forcelist for status in (500, 502, 503, 504, 599))
+
+
+def test_retry_backoff_never_exceeds_five_seconds():
+    """Even with exponential growth and jitter, no single retry should wait
+    longer than 5 seconds, no matter how many retries have already happened."""
+    retry = Client(should_validate_auth=False)._session().get_adapter(
+        'https://harmony.earthdata.nasa.gov'
+    ).max_retries
+
+    # total=5 means at most 5 increments are possible before retries are exhausted
+    for _ in range(5):
+        retry = retry.increment(
+            method='POST',
+            url='https://harmony.earthdata.nasa.gov/jobs/status',
+            error=requests.exceptions.ConnectionError('boom'),
+        )
+        assert 0 <= retry.get_backoff_time() <= 5
+
+
+def test_retry_configuration_permits_connection_error_retry_for_post():
+    """Connection errors must be retryable for POST requests (submit,
+    submit_batch, and batch job-status polling all issue POSTs), not just the
+    GET-based endpoints that were retried before this change."""
+    retry = Client(should_validate_auth=False)._session().get_adapter(
+        'https://harmony.earthdata.nasa.gov'
+    ).max_retries
+
+    retried = retry.increment(
+        method='POST',
+        url='https://harmony.earthdata.nasa.gov/jobs/status',
+        error=requests.exceptions.ConnectionError('Connection refused'),
+    )
+
+    assert retried.total == retry.total - 1
+
+
+@responses.activate(registry=registries.OrderedRegistry)
+def test_submit_retries_on_5xx_then_succeeds():
+    collection = Collection(id='C1342468263-ANYTHING')
+    request = Request(collection=collection, spatial=BBox(-107, 40, -105, 42))
+    job_id = 'abcd-1234'
+
+    for _ in range(3):
+        responses.add(
+            responses.POST, expected_submit_url(collection.id), status=503, json='error'
+        )
+    responses.add(
+        responses.POST,
+        expected_submit_url(collection.id),
+        status=200,
+        json=expected_job(collection.id, job_id),
+    )
+
+    actual_job_id = Client(should_validate_auth=False).submit(request)
+
+    assert actual_job_id == job_id
+    assert len(responses.calls) == 4
+
+
+@responses.activate(registry=registries.OrderedRegistry)
+def test_submit_exhausts_retries_and_raises():
+    collection = Collection(id='C1342468263-ANYTHING')
+    request = Request(collection=collection, spatial=BBox(-107, 40, -105, 42))
+
+    # total=5 retries means 6 total attempts before giving up
+    for _ in range(6):
+        responses.add(
+            responses.POST, expected_submit_url(collection.id), status=502, json='error'
+        )
+
+    with pytest.raises(Exception) as e:
+        Client(should_validate_auth=False).submit(request)
+
+    assert '502 Server Error' in str(e.value)
+    assert len(responses.calls) == 6
+
+
+@responses.activate(registry=registries.OrderedRegistry)
+def test_poll_job_statuses_retries_on_5xx_then_succeeds():
+    job_ids = ['job-1', 'job-2']
+    exp_body = {
+        'jobStatuses': [
+            {'jobID': 'job-1', 'status': 'running', 'progress': 42},
+            {'jobID': 'job-2', 'status': 'successful', 'progress': 100},
+        ],
+        'notFoundJobIDs': [],
+    }
+
+    for _ in range(2):
+        responses.add(
+            responses.POST, expected_job_status_batch_url(), status=504, json='error'
+        )
+    responses.add(
+        responses.POST, expected_job_status_batch_url(), status=200, json=exp_body
+    )
+
+    statuses = Client(should_validate_auth=False)._poll_job_statuses(job_ids)
+
+    assert statuses['job-1']['status'] == 'running'
+    assert statuses['job-2']['status'] == 'successful'
+    assert len(responses.calls) == 3
 
 
 def test_request_as_curl_get():
@@ -2148,6 +2414,174 @@ def test_download_intermediate_files_requires_work_items():
     client = Client(should_validate_auth=False)
     with pytest.raises(ValueError):
         list(client.download_intermediate_files('jobs-uuid', work_items=[]))
+
+
+def test_submit_batch(mocker):
+    client = Client(should_validate_auth=False)
+    requests = [mocker.Mock(name=f'request-{i}') for i in range(3)]
+    job_ids_by_request = {id(r): f'job-{i}' for i, r in enumerate(requests)}
+    submit_mock = mocker.patch.object(
+        client, 'submit', side_effect=lambda r: job_ids_by_request[id(r)]
+    )
+
+    result = client.submit_batch(requests)
+
+    assert result == ['job-0', 'job-1', 'job-2']
+    assert submit_mock.call_count == 3
+    for r in requests:
+        submit_mock.assert_any_call(r)
+
+
+def test_submit_batch_raises_on_failed_submission(mocker):
+    client = Client(should_validate_auth=False)
+
+    def fake_submit(request):
+        if request == 'bad-request':
+            raise Exception('submission failed')
+        return 'job-ok'
+
+    mocker.patch.object(client, 'submit', side_effect=fake_submit)
+
+    with pytest.raises(Exception, match='submission failed'):
+        client.submit_batch(['bad-request', 'good-request'])
+
+
+def test_wait_for_batch(mocker):
+    client = Client(should_validate_auth=False)
+    job_statuses = {
+        'job-1': {'status': 'successful', 'progress': 100},
+        'job-2': {'status': 'failed', 'progress': 100},
+        'job-3': {'status': 'canceled', 'progress': 100},
+        'job-4': {'status': 'successful', 'progress': 100},
+    }
+    poll_mock = mocker.patch.object(
+        client,
+        '_poll_job_statuses',
+        side_effect=lambda job_ids: {j: job_statuses[j] for j in job_ids},
+    )
+
+    result = client.wait_for_batch(list(job_statuses.keys()))
+
+    assert result.job_ids['successful'] == ['job-1', 'job-4']
+    assert result.job_ids['failed'] == ['job-2']
+    assert result.job_ids['canceled'] == ['job-3']
+    assert result.job_ids['paused'] == []
+    assert result.job_ids['complete_with_errors'] == []
+    assert result.counts == {
+        'successful': 2,
+        'failed': 1,
+        'canceled': 1,
+        'paused': 0,
+        'complete_with_errors': 0,
+    }
+    # Statuses that never showed up in this batch still default rather than raising.
+    assert result.job_ids['some_future_status'] == []
+    assert result.counts['some_future_status'] == 0
+    # All jobs finish in a single round, so this is a single batch call, not one per job.
+    poll_mock.assert_called_once_with(list(job_statuses.keys()))
+
+
+def test_wait_for_batch_polls_until_terminal(mocker):
+    client = Client(should_validate_auth=False)
+    status_sequence = iter(
+        [
+            {'job-1': {'status': 'running', 'progress': 50}},
+            {'job-1': {'status': 'successful', 'progress': 100}},
+        ]
+    )
+    sleep_mock = mocker.patch('harmony.client.time.sleep')
+    poll_mock = mocker.patch.object(
+        client, '_poll_job_statuses', side_effect=lambda job_ids: next(status_sequence)
+    )
+
+    result = client.wait_for_batch(['job-1'])
+
+    assert result.job_ids['successful'] == ['job-1']
+    assert result.counts['successful'] == 1
+    assert poll_mock.call_count == 2
+    sleep_mock.assert_called_once_with(client.check_interval)
+
+
+def test_wait_for_batch_with_show_progress(mocker):
+    client = Client(should_validate_auth=False)
+    job_statuses = {
+        'job-1': {'status': 'successful', 'progress': 100},
+        'job-2': {'status': 'successful', 'progress': 100},
+    }
+    poll_mock = mocker.patch.object(
+        client,
+        '_poll_job_statuses',
+        side_effect=lambda job_ids: {j: job_statuses[j] for j in job_ids},
+    )
+
+    progressbar_mock = mocker.Mock()
+    progressbar_mock.__enter__ = lambda _: progressbar_mock
+    progressbar_mock.__exit__ = lambda a, b, d, c: None
+    mocker.patch('harmony.client.progressbar.ProgressBar', return_value=progressbar_mock)
+
+    result = client.wait_for_batch(list(job_statuses.keys()), show_progress=True)
+
+    poll_mock.assert_called_once_with(['job-1', 'job-2'])
+    assert sorted(result.job_ids['successful']) == ['job-1', 'job-2']
+    assert result.job_ids['failed'] == []
+    progressbar_mock.update.assert_any_call(2)
+
+
+def test_download_batch(mocker):
+    client = Client(should_validate_auth=False)
+    fake_results = {
+        'job-1': ['/tmp/file1', '/tmp/file2'],
+        'job-2': ['/tmp/file3'],
+    }
+    mocker.patch.object(
+        client,
+        'download_all',
+        side_effect=lambda job_id, directory='', overwrite=False: iter(fake_results[job_id]),
+    )
+
+    results = client.download_batch(list(fake_results.keys()))
+
+    assert results == fake_results
+
+
+def test_download_batch_passes_directory_and_overwrite(mocker):
+    client = Client(should_validate_auth=False)
+    download_all_mock = mocker.patch.object(client, 'download_all', return_value=iter([]))
+
+    client.download_batch(['job-1'], directory='/tmp', overwrite=True)
+
+    download_all_mock.assert_called_once_with('job-1', '/tmp', True)
+
+
+def test_download_batch_empty_results_for_failed_job(mocker):
+    client = Client(should_validate_auth=False)
+    mocker.patch.object(client, 'download_all', return_value=iter([]))
+
+    results = client.download_batch(['failed-job'])
+
+    assert results == {'failed-job': []}
+
+
+def test_download_batch_mixed_statuses_and_no_outputs(mocker):
+    # Callers shouldn't have to filter job_ids by status first -- jobs with no output
+    # files, regardless of why (failed, canceled, or simply succeeded with nothing to
+    # return), should just come back as an empty list alongside jobs that do have files.
+    client = Client(should_validate_auth=False)
+    fake_results = {
+        'successful-with-files': ['/tmp/file1', '/tmp/file2'],
+        'successful-no-files': [],
+        'failed-job': [],
+        'canceled-job': [],
+    }
+    mocker.patch.object(
+        client,
+        'download_all',
+        side_effect=lambda job_id, directory='', overwrite=False: iter(fake_results[job_id]),
+    )
+
+    results = client.download_batch(list(fake_results.keys()))
+
+    assert results == fake_results
 
 
 def test_client_environment_not_affected_by_env_var():


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2420

## Description
Provide functions for submitting a batch of requests to harmony, waiting for a batch of jobs to finish, and downloading all the outputs from a batch of jobs.

This also changes all polling for job status within existing functions which poll a single job to use the new lightweight /jobs/status endpoint on harmony reducing the load on harmony and returning status to the client faster.

Also fixes a race condition downloading multiple files from a download site backed by EDL authentication.

## Local Test Steps
Run `make examples` and then run through the `batch_processing.ipynb` notebook which demonstrates all three functions.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [X] Documentation updated (if needed)